### PR TITLE
Fix published version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ allprojects {
     apply plugin: 'idea'
 
     group = 'io.spine'
-    version = spineVersion
+    version = versionToPublish
 }
 
 ext {


### PR DESCRIPTION
Before, instead of `versionToPublish`, `spineVersion` was used for publishing.
Now we can separate those.