### PR TITLE
Set Aggregate Part ID on first event

### DIFF
--- a/users/src/main/java/io/spine/users/c/user/UserMembershipPart.java
+++ b/users/src/main/java/io/spine/users/c/user/UserMembershipPart.java
@@ -6,9 +6,7 @@
 
 package io.spine.users.c.user;
 
-import io.spine.core.CommandContext;
 import io.spine.core.UserId;
-import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.AggregatePart;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
@@ -26,21 +24,16 @@ import static io.spine.users.c.user.RoleInGroup.MEMBER;
  *
  * <p>If a user shares its functions and roles with a number of other users they can join
  * one or more groups (please see {@link JoinGroup}, {@link LeaveGroup} commands).
- *
- * @author Vladyslav Lubenskyi
  */
 public class UserMembershipPart
         extends AggregatePart<UserId, UserMembership, UserMembershipVBuilder, UserRoot> {
 
-    /**
-     * @see Aggregate#Aggregate(Object)
-     */
     UserMembershipPart(UserRoot root) {
         super(root);
     }
 
     @Assign
-    UserJoinedGroup handle(JoinGroup command, CommandContext context) {
+    UserJoinedGroup handle(JoinGroup command) {
         UserJoinedGroup event =
                 UserJoinedGroupVBuilder
                         .newBuilder()
@@ -52,7 +45,7 @@ public class UserMembershipPart
     }
 
     @Assign
-    UserLeftGroup handle(LeaveGroup command, CommandContext context) {
+    UserLeftGroup handle(LeaveGroup command) {
         UserLeftGroup event =
                 UserLeftGroupVBuilder
                         .newBuilder()
@@ -70,14 +63,16 @@ public class UserMembershipPart
                         .setGroupId(event.getGroupId())
                         .setRole(event.getRole())
                         .build();
-        getBuilder().addMembership(membershipRecord);
-
+        getBuilder()
+                .setId(getId())
+                .addMembership(membershipRecord);
     }
 
     @Apply
     void on(UserLeftGroup event) {
         Optional<UserMembershipRecord> membership = findMembership(event.getGroupId());
         membership.ifPresent(this::removeMembership);
+        getBuilder().setId(getId());
     }
 
     private void removeMembership(UserMembershipRecord record) {

--- a/users/src/test/java/io/spine/users/c/user/JoinGroupTest.java
+++ b/users/src/test/java/io/spine/users/c/user/JoinGroupTest.java
@@ -12,9 +12,6 @@ import org.junit.jupiter.api.Test;
 import static io.spine.users.c.user.given.UserTestCommands.startGroupMembership;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * @author Vladyslav Lubenskyi
- */
 @DisplayName("JoinGroup command should")
 class JoinGroupTest extends UserMembershipCommandTest<JoinGroup> {
 
@@ -25,7 +22,7 @@ class JoinGroupTest extends UserMembershipCommandTest<JoinGroup> {
     @Test
     @DisplayName("generate UserJoinedGroup event")
     void generateEvent() {
-        UserMembershipPart part = createPartWithState();
+        UserMembershipPart part = createPart();
         expectThat(part).producesEvent(UserJoinedGroup.class, event -> {
             assertEquals(message().getId(), event.getId());
             assertEquals(message().getGroupId(), event.getGroupId());
@@ -35,7 +32,7 @@ class JoinGroupTest extends UserMembershipCommandTest<JoinGroup> {
     @Test
     @DisplayName("add a new group membership")
     void changeState() {
-        UserMembershipPart part = createPartWithState();
+        UserMembershipPart part = createPart();
         expectThat(part).hasState(
                 state -> assertEquals(message().getGroupId(), state.getMembership(0)
                                                                    .getGroupId()));

--- a/users/src/test/java/io/spine/users/c/user/UserMembershipCommandTest.java
+++ b/users/src/test/java/io/spine/users/c/user/UserMembershipCommandTest.java
@@ -12,6 +12,7 @@ import io.spine.server.entity.Repository;
 import io.spine.testing.server.aggregate.AggregateCommandTest;
 
 import static io.spine.testing.server.TestBoundedContext.create;
+import static io.spine.users.c.user.TestUserFactory.createEmptyMembershipPart;
 import static io.spine.users.c.user.TestUserFactory.createMembershipPart;
 import static io.spine.users.c.user.given.UserTestEnv.userId;
 
@@ -37,6 +38,10 @@ abstract class UserMembershipCommandTest<C extends CommandMessage>
 
     protected UserMembershipPart createPartWithState() {
         return createMembershipPart(root(USER_ID));
+    }
+
+    protected UserMembershipPart createPart() {
+        return createEmptyMembershipPart(root(USER_ID));
     }
 
     private static UserRoot root(UserId id) {


### PR DESCRIPTION
Previously, an ID was never set to the `UserMembershipPart` state.
The tests did not indicate the issue because of the pre-built entity state, which was used to test command handling.