### PR TITLE
Fix ID `set_once` errors

### DIFF
--- a/users/src/main/java/io/spine/users/server/user/UserMembershipPart.java
+++ b/users/src/main/java/io/spine/users/server/user/UserMembershipPart.java
@@ -93,7 +93,6 @@ public class UserMembershipPart
     void on(UserLeftGroup event) {
         Optional<UserMembershipRecord> membership = findMembership(event.getGroupId());
         membership.ifPresent(this::removeMembership);
-        getBuilder().setId(getId());
     }
 
     private void removeMembership(UserMembershipRecord record) {

--- a/users/src/main/proto/spine/users/google_identifiers.proto
+++ b/users/src/main/proto/spine/users/google_identifiers.proto
@@ -22,7 +22,6 @@ syntax = "proto3";
 
 package spine.users;
 
-import "spine/core/user_id.proto";
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.io";

--- a/users/src/main/proto/spine/users/group/group.proto
+++ b/users/src/main/proto/spine/users/group/group.proto
@@ -118,7 +118,7 @@ message GroupMembership {
 message GroupRolesPropagation {
     option (entity).kind = PROCESS_MANAGER;
 
-    GroupId id = 1;
+    GroupId id = 1 [(set_once) = false];
 
     // A list of `User` members. Only direct members of the group are included.
     repeated core.UserId user_member = 2;

--- a/users/src/main/proto/spine/users/person_profile.proto
+++ b/users/src/main/proto/spine/users/person_profile.proto
@@ -30,7 +30,6 @@ option java_outer_classname = "UserProfileProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
-import "spine/core/user_id.proto";
 import "spine/net/email_address.proto";
 import "spine/net/url.proto";
 import "spine/people/person_name.proto";


### PR DESCRIPTION
This PR disables the `set_once` for `GroupRolesPropagation`  because the process manager can be created from different events. 

The `UserMembershipPart` had redundant ID assignment.

Redundant ID imports are removed.
