### PR TITLE
Enable build-time PMD checks and rename `IdentityProviderBridge`

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -64,7 +64,6 @@
           <item value="java.lang.Throwable" />
           <item value="java.lang.Exception" />
           <item value="java.lang.Error" />
-          <item value="java.lang.NullPointerException" />
           <item value="java.lang.ClassCastException" />
           <item value="java.lang.ArrayIndexOutOfBoundsException" />
         </value>
@@ -93,7 +92,12 @@
     <inspection_tool class="ClassComplexity" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_limit" value="80" />
     </inspection_tool>
-    <inspection_tool class="ClassCoupling" enabled="true" level="WARNING" enabled_by_default="true">
+    <inspection_tool class="ClassCoupling" enabled="true" level="TYPO" enabled_by_default="true">
+      <scope name="Production" level="WARNING" enabled="true">
+        <option name="m_includeJavaClasses" value="false" />
+        <option name="m_includeLibraryClasses" value="false" />
+        <option name="m_limit" value="15" />
+      </scope>
       <option name="m_includeJavaClasses" value="false" />
       <option name="m_includeLibraryClasses" value="false" />
       <option name="m_limit" value="15" />
@@ -148,6 +152,14 @@
     <inspection_tool class="ConfusingMainMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingOctalEscape" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="ConstantConditions" enabled="true" level="TYPO" enabled_by_default="true">
+      <scope name="Production" level="WARNING" enabled="true">
+        <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="true" />
+        <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
+      </scope>
+      <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="true" />
+      <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
+    </inspection_tool>
     <inspection_tool class="ConstantNamingConvention" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="onlyCheckImmutables" value="true" />
       <option name="m_regex" value="[A-Z_\d]*" />
@@ -183,7 +195,7 @@
       <option name="CHECK_DUPLICATE_KEYS" value="true" />
       <option name="CHECK_DUPLICATE_KEYS_WITH_DIFFERENT_VALUES" value="true" />
     </inspection_tool>
-    <inspection_tool class="DuplicateStringLiteralInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+    <inspection_tool class="DuplicateStringLiteralInspection" enabled="true" level="TYPO" enabled_by_default="true">
       <scope name="Production" level="WARNING" enabled="true">
         <option name="MIN_STRING_LENGTH" value="5" />
         <option name="IGNORE_PROPERTY_KEYS" value="false" />
@@ -194,7 +206,9 @@
     <inspection_tool class="DynamicRegexReplaceableByCompiledPattern" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EmptyClass" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignorableAnnotations">
-        <value />
+        <value>
+          <item value="org.junit.jupiter.api.DisplayName" />
+        </value>
       </option>
       <option name="ignoreClassWithParameterization" value="true" />
       <option name="ignoreThrowables" value="true" />
@@ -204,6 +218,9 @@
     <inspection_tool class="EmptyInitializer" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EmptySynchronizedStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Tests" level="TYPO" enabled="true">
+        <option name="ignoreSwitchStatementsWithDefault" value="false" />
+      </scope>
       <option name="ignoreSwitchStatementsWithDefault" value="false" />
     </inspection_tool>
     <inspection_tool class="EnumerationCanBeIteration" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -266,7 +283,10 @@
     </inspection_tool>
     <inspection_tool class="InconsistentLanguageLevel" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="IncrementDecrementUsedAsExpression" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InnerClassMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="InnerClassMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Production" level="WARNING" enabled="true" />
+      <scope name="Tests" level="WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="InstanceMethodNamingConvention" enabled="true" level="INFO" enabled_by_default="true">
       <scope name="Tests" level="INFO" enabled="false">
         <option name="m_regex" value="[a-z][A-Za-z\d]*" />
@@ -323,8 +343,45 @@
     <inspection_tool class="IteratorNextDoesNotThrowNoSuchElementException" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JDBCExecuteWithNonConstantString" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JDBCPrepareStatementWithNonConstantString" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="JUnit5Converter" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="JavaDoc" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="TOP_LEVEL_CLASS_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
+          <option name="REQUIRED_TAGS" value="" />
+        </value>
+      </option>
+      <option name="INNER_CLASS_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
+          <option name="REQUIRED_TAGS" value="" />
+        </value>
+      </option>
+      <option name="METHOD_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
+          <option name="REQUIRED_TAGS" value="" />
+        </value>
+      </option>
+      <option name="FIELD_OPTIONS">
+        <value>
+          <option name="ACCESS_JAVADOC_REQUIRED_FOR" value="none" />
+          <option name="REQUIRED_TAGS" value="" />
+        </value>
+      </option>
+      <option name="IGNORE_DEPRECATED" value="false" />
+      <option name="IGNORE_JAVADOC_PERIOD" value="false" />
+      <option name="IGNORE_DUPLICATED_THROWS" value="false" />
+      <option name="IGNORE_POINT_TO_ITSELF" value="false" />
+      <option name="myAdditionalJavadocTags" value="" />
+      <IGNORE_DUPLICATED_THROWS_TAGS value="false" />
+    </inspection_tool>
     <inspection_tool class="JavaLangImport" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JavaLangReflect" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="JavadocHtmlLint" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="JavadocReference" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="Tests" level="ERROR" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="LabeledStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LengthOneStringInIndexOf" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LengthOneStringsInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -340,6 +397,13 @@
       <option name="REPORT_FOREACH_PARAMETERS" value="false" />
     </inspection_tool>
     <inspection_tool class="LocalVariableNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Tests" level="TYPO" enabled="true">
+        <option name="m_ignoreForLoopParameters" value="true" />
+        <option name="m_ignoreCatchParameters" value="true" />
+        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+        <option name="m_minLength" value="2" />
+        <option name="m_maxLength" value="25" />
+      </scope>
       <option name="m_ignoreForLoopParameters" value="true" />
       <option name="m_ignoreCatchParameters" value="true" />
       <option name="m_regex" value="[a-z][A-Za-z\d]*" />
@@ -391,6 +455,7 @@
       <option name="ignoreObjectMethods" value="false" />
       <option name="ignoreAnonymousClassMethods" value="false" />
     </inspection_tool>
+    <inspection_tool class="MissingPackageInfo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MissortedModifiers" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_requireAnnotationsFirst" value="true" />
     </inspection_tool>
@@ -419,7 +484,17 @@
     </inspection_tool>
     <inspection_tool class="NewExceptionWithoutArguments" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NewMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Tests" level="INFO" enabled="false" />
+      <scope name="Tests" level="INFO" enabled="true">
+        <extension name="InstanceMethodNamingConvention" enabled="true">
+          <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+          <option name="m_minLength" value="2" />
+          <option name="m_maxLength" value="32" />
+        </extension>
+        <extension name="JUnit4MethodNamingConvention" enabled="true">
+          <option name="m_regex" value="[a-z][A-Za-z\d]*" />
+          <option name="m_minLength" value="2" />
+        </extension>
+      </scope>
       <scope name="Production" level="WARNING" enabled="true">
         <extension name="InstanceMethodNamingConvention" enabled="true">
           <option name="m_regex" value="[a-z][A-Za-z\d]*" />
@@ -516,6 +591,7 @@
     <inspection_tool class="OverriddenMethodCallDuringObjectConstruction" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageDotHtmlMayBePackageInfo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageInMultipleModules" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PackageInfoWithoutPackage" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_regex" value="[a-z]+\d*[a-z]*" />
       <option name="m_minLength" value="2" />
@@ -548,8 +624,8 @@
       <option name="ignoreEnums" value="false" />
       <option name="ignorableAnnotations">
         <value>
-          <item value="org.junit.Rule" />
           <item value="org.junit.Test" />
+          <item value="org.junit.Rule" />
         </value>
       </option>
     </inspection_tool>
@@ -566,6 +642,7 @@
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="RedundantSuppression" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -635,6 +712,9 @@
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_limit" value="2" />
+    </inspection_tool>
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -691,6 +771,7 @@
     <inspection_tool class="TransientFieldNotInitialized" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TrivialIf" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TypeMayBeWeakened" enabled="true" level="INFO" enabled_by_default="true">
       <scope name="Tests" level="INFO" enabled="true">
         <option name="useRighthandTypeAsWeakestTypeInAssignments" value="true" />
@@ -723,8 +804,12 @@
     <inspection_tool class="UnnecessaryConstructor" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="ignoreAnnotations" value="true" />
     </inspection_tool>
-    <inspection_tool class="UnnecessaryDefault" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UnnecessaryDefault" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryExplicitNumericCast" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UnnecessaryInheritDoc" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UnnecessaryJavaDocLink" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreInlineLinkToSuper" value="false" />
+    </inspection_tool>
     <inspection_tool class="UnnecessaryLocalVariable" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreImmediatelyReturnedVariables" value="true" />
       <option name="m_ignoreAnnotatedVariables" value="false" />
@@ -740,10 +825,14 @@
       <option name="ignoreReferencesToLocalInnerClasses" value="true" />
     </inspection_tool>
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UnstableApiUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WEAK WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="UnusedCatchParameter" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreCatchBlocksWithComments" value="true" />
       <option name="m_ignoreTestCases" value="true" />
     </inspection_tool>
+    <inspection_tool class="UnusedReturnValue" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="UpperCaseFieldNameNotConstant" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UseOfAWTPeerClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UseOfJDBCDriverClass" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -760,6 +849,7 @@
       <option name="ignorableAnnotations">
         <value>
           <item value="com.google.common.annotations.VisibleForTesting" />
+          <item value="org.junit.jupiter.api.DisplayName" />
         </value>
       </option>
       <option name="ignoreClassesWithOnlyMain" value="false" />

--- a/build.gradle
+++ b/build.gradle
@@ -84,8 +84,10 @@ subprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
-
     apply plugin: spineModelCompilerId
+    
+    apply plugin: 'pmd'
+    apply from: deps.scripts.pmd
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/users/src/main/java/io/spine/users/server/Directory.java
+++ b/users/src/main/java/io/spine/users/server/Directory.java
@@ -24,33 +24,32 @@ import io.spine.users.PersonProfile;
 import io.spine.users.user.Identity;
 
 /**
- * A bridge to an authentication identity provider.
+ * A user identity management system.
  *
  * <p>The {@code Users} bounded context is a framework solution and thus relies upon the third-party
- * authentication providers supplied by the particular application.
+ * authentication supplied by the particular application.
  *
- * <p>For {@code Users}, an authentication provider serves as a data source and the single
- * source of truth about {@linkplain Identity user authentication identities}.
+ * <p>For {@code Users}, a directory serves as a data source and the single source of truth about
+ * {@linkplain Identity user authentication identities}.
  *
- * <p>This interface may be used both for application's own and remote identity
- * providers. For example:
+ * <p>This interface may be used both for application's own and remote user data sources.
+ * For example:
  *
  * <ul>
  *     <li>Spring Security;
  *     <li>Google Directory API;
  *     <li>Active Directory.
  * </ul>
- *
- * @author Vladyslav Lubenskyi
  */
-public interface IdentityProviderBridge {
+public interface Directory {
 
     /**
-     * Checks whether an identity provider is aware of the given identity.
+     * Checks whether the directory is aware of the given identity.
      *
-     * @param identity an authentication identity to check
-     * @return {@code true} if the given identity is indeed provided by the provider,
-     * {@code false} otherwise
+     * @param identity
+     *         an authentication identity to check
+     * @return {@code true} if the given identity is known to this directory,
+     *         {@code false} otherwise
      */
     boolean hasIdentity(Identity identity);
 
@@ -60,7 +59,8 @@ public interface IdentityProviderBridge {
      * <p>For example, the specific implementation may check if an associated user account is still
      * active or has a permission to sign-in.
      *
-     * @param identity an authentication identity to check
+     * @param identity
+     *         an authentication identity to check
      * @return {@code true} if the given identity is allowed to sign-in, {@code false} otherwise
      */
     boolean isSignInAllowed(Identity identity);
@@ -68,8 +68,9 @@ public interface IdentityProviderBridge {
     /**
      * Fetches the profile of the user associated with the given identity.
      *
-     * @param identity an identity of the user
-     * @return a user profile
+     * @param identity
+     *         an identity of the user
+     * @return the user profile
      */
     PersonProfile fetchProfile(Identity identity);
 }

--- a/users/src/main/java/io/spine/users/server/Directory.java
+++ b/users/src/main/java/io/spine/users/server/Directory.java
@@ -35,7 +35,7 @@ import io.spine.users.user.Identity;
  * <p>This interface may be used both for application's own and remote user data sources.
  * For example:
  *
- * <ul
+ * <ul>
  *     <li>Spring Security;
  *     <li>Google Directory API;
  *     <li>Active Directory.

--- a/users/src/main/java/io/spine/users/server/Directory.java
+++ b/users/src/main/java/io/spine/users/server/Directory.java
@@ -24,7 +24,7 @@ import io.spine.users.PersonProfile;
 import io.spine.users.user.Identity;
 
 /**
- * A user identity management system.
+ * A facade above a source of information about users of a system.
  *
  * <p>The {@code Users} bounded context is a framework solution and thus relies upon the third-party
  * authentication supplied by the particular application.
@@ -35,7 +35,7 @@ import io.spine.users.user.Identity;
  * <p>This interface may be used both for application's own and remote user data sources.
  * For example:
  *
- * <ul>
+ * <ul
  *     <li>Spring Security;
  *     <li>Google Directory API;
  *     <li>Active Directory.

--- a/users/src/main/java/io/spine/users/server/DirectoryFactory.java
+++ b/users/src/main/java/io/spine/users/server/DirectoryFactory.java
@@ -20,7 +20,7 @@
 
 package io.spine.users.server;
 
-import io.spine.users.IdentityProviderId;
+import io.spine.users.DirectoryId;
 
 import java.util.Optional;
 
@@ -31,12 +31,11 @@ import java.util.Optional;
 public interface DirectoryFactory {
 
     /**
-     * Obtains or creates a {@link Directory bridge} to communicate with
-     * an authentication identity provider.
+     * Obtains or creates a {@link Directory} instance to communicate with a user management system.
      *
-     * @param id a unique identifier of the identity provider
-     * @return {@link Directory} if the requested identity provider is supported,
-     * {@code Optional.empty()} otherwise
+     * @param id a unique identifier of the directory
+     * @return {@link Directory} if the requested directory is supported,
+     *         {@code Optional.empty()} otherwise
      */
-    Optional<Directory> get(IdentityProviderId id);
+    Optional<Directory> get(DirectoryId id);
 }

--- a/users/src/main/java/io/spine/users/server/DirectoryFactory.java
+++ b/users/src/main/java/io/spine/users/server/DirectoryFactory.java
@@ -18,34 +18,25 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.users.server.signin;
+package io.spine.users.server;
 
-import io.spine.base.EventMessage;
-import io.spine.core.UserId;
-import io.spine.server.entity.Repository;
-import io.spine.testing.server.procman.PmCommandOnEventTest;
-import io.spine.users.server.DirectoryFactory;
-import io.spine.users.server.user.UserPartRepository;
-import io.spine.users.signin.SignIn;
+import io.spine.users.IdentityProviderId;
 
-import static org.mockito.Mockito.mock;
+import java.util.Optional;
 
 /**
- * An implementation base for the {@link SignInPm} event reactors tests.
- *
- * @param <E> the type of the event being tested
- * @author Vladyslav Lubenskyi
+ * A factory for creating {@link Directory} instances.
  */
-abstract class SignInPmEventTest<E extends EventMessage>
-        extends PmCommandOnEventTest<UserId, E, SignIn, SignInPm> {
+@FunctionalInterface
+public interface DirectoryFactory {
 
-    SignInPmEventTest(UserId processManagerId, E eventMessage) {
-        super(processManagerId, eventMessage);
-    }
-
-    @Override
-    protected Repository<UserId, SignInPm> createRepository() {
-        return new SignInPmRepository(mock(DirectoryFactory.class),
-                                      mock(UserPartRepository.class));
-    }
+    /**
+     * Obtains or creates a {@link Directory bridge} to communicate with
+     * an authentication identity provider.
+     *
+     * @param id a unique identifier of the identity provider
+     * @return {@link Directory} if the requested identity provider is supported,
+     * {@code Optional.empty()} otherwise
+     */
+    Optional<Directory> get(IdentityProviderId id);
 }

--- a/users/src/main/java/io/spine/users/server/group/google/GoogleGroupLifecyclePm.java
+++ b/users/src/main/java/io/spine/users/server/group/google/GoogleGroupLifecyclePm.java
@@ -118,7 +118,8 @@ public class GoogleGroupLifecyclePm extends ProcessManager<GroupId,
         return commands().changeDescription(event);
     }
 
-    private Optional<OrganizationId> organizationByDomain(InternetDomain domain) {
+    private Optional<OrganizationId>
+    organizationByDomain(@SuppressWarnings("PMD.UnusedFormalParameter") InternetDomain domain) {
         // TODO:2018-09-27:vladyslav.lubenskyi: implement this look up when Organization
         //  projection is ready
         return empty();

--- a/users/src/main/java/io/spine/users/server/group/google/GoogleGroupLifecyclePm.java
+++ b/users/src/main/java/io/spine/users/server/group/google/GoogleGroupLifecyclePm.java
@@ -120,7 +120,7 @@ public class GoogleGroupLifecyclePm extends ProcessManager<GroupId,
 
     private Optional<OrganizationId> organizationByDomain(InternetDomain domain) {
         // TODO:2018-09-27:vladyslav.lubenskyi: implement this look up when Organization
-        // projection is ready
+        //  projection is ready
         return empty();
     }
 

--- a/users/src/main/java/io/spine/users/server/organization/OrganizationAggregate.java
+++ b/users/src/main/java/io/spine/users/server/organization/OrganizationAggregate.java
@@ -52,12 +52,11 @@ import io.spine.users.orgunit.OrgUnit;
  *
  * @author Vladyslav Lubenskyi
  */
-@SuppressWarnings("OverlyCoupledClass") // It is OK for an aggregate.
 public class OrganizationAggregate
         extends Aggregate<OrganizationId, Organization, OrganizationVBuilder> {
 
     /**
-     * @see OrganizationAggregate#OrganizationAggregate(OrganizationId)
+     * @see Aggregate#Aggregate(Object)
      */
     OrganizationAggregate(OrganizationId id) {
         super(id);

--- a/users/src/main/java/io/spine/users/server/signin/SignInPm.java
+++ b/users/src/main/java/io/spine/users/server/signin/SignInPm.java
@@ -81,7 +81,7 @@ import static java.util.Optional.of;
  *
  * <ul>
  *     <li>a {@linkplain Directory} is aware of the given authentication identity;
- *     <li>the directory authorizes the user to sign in (e.g. the opposite would be if the user
+ *     <li>the directory authorizes the user to sign-in (e.g. the opposite would be if the user
  *         account was suspended);
  *     <li>the given authentication identity is associated with the user (that is, serves as the
  *         primary or a secondary authentication identity).

--- a/users/src/main/java/io/spine/users/server/signin/SignInPm.java
+++ b/users/src/main/java/io/spine/users/server/signin/SignInPm.java
@@ -80,9 +80,8 @@ import static java.util.Optional.of;
  * <p>To sign a user in, the process manager ensures the following:
  *
  * <ul>
- *     <li>an {@linkplain Directory identity provider} is aware of the given
- *         authentication identity;
- *     <li>an identity provider authorize the user to sign in (e.g. the opposite would be if the user
+ *     <li>a {@linkplain Directory} is aware of the given authentication identity;
+ *     <li>the directory authorizes the user to sign in (e.g. the opposite would be if the user
  *         account was suspended);
  *     <li>the given authentication identity is associated with the user (that is, serves as the
  *         primary or a secondary authentication identity).
@@ -118,7 +117,7 @@ public class SignInPm extends ProcessManager<UserId, SignIn, SignInVBuilder> {
         UserId id = command.getId();
         Identity identity = command.getIdentity();
         Optional<Directory> directoryOptional =
-                directories.get(identity.getProviderId());
+                directories.get(identity.getDirectoryId());
         if (!directoryOptional.isPresent()) {
             return withA(finishWithError(UNSUPPORTED_IDENTITY));
         }
@@ -171,8 +170,8 @@ public class SignInPm extends ProcessManager<UserId, SignIn, SignInVBuilder> {
         return signOutCompleted(command.getId());
     }
 
-    private CreateUser createUser(Directory identityProvider) {
-        PersonProfile profile = identityProvider.fetchProfile(getBuilder().getIdentity());
+    private CreateUser createUser(Directory directory) {
+        PersonProfile profile = directory.fetchProfile(getBuilder().getIdentity());
         return createUser(getBuilder().getIdentity(), profile);
     }
 

--- a/users/src/main/java/io/spine/users/server/signin/SignInPmRepository.java
+++ b/users/src/main/java/io/spine/users/server/signin/SignInPmRepository.java
@@ -26,6 +26,8 @@ import io.spine.users.server.DirectoryFactory;
 import io.spine.users.server.user.UserPartRepository;
 import io.spine.users.signin.SignIn;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * The repository for {@link SignInPm}.
  *
@@ -34,20 +36,20 @@ import io.spine.users.signin.SignIn;
 public class SignInPmRepository extends ProcessManagerRepository<UserId, SignInPm, SignIn> {
 
     private final UserPartRepository userRepository;
-    private final DirectoryFactory identityProviderFactory;
+    private final DirectoryFactory directoryFactory;
 
-    public SignInPmRepository(DirectoryFactory identityProviderFactory,
+    public SignInPmRepository(DirectoryFactory directoryFactory,
                               UserPartRepository userRepository) {
         super();
-        this.identityProviderFactory = identityProviderFactory;
-        this.userRepository = userRepository;
+        this.directoryFactory = checkNotNull(directoryFactory);
+        this.userRepository = checkNotNull(userRepository);
     }
 
     @Override
     protected SignInPm findOrCreate(UserId id) {
         SignInPm processManager = super.findOrCreate(id);
         processManager.setUserRepository(userRepository);
-        processManager.setDirectoryFactory(identityProviderFactory);
+        processManager.setDirectoryFactory(directoryFactory);
         return processManager;
     }
 }

--- a/users/src/main/java/io/spine/users/server/signin/SignInPmRepository.java
+++ b/users/src/main/java/io/spine/users/server/signin/SignInPmRepository.java
@@ -22,7 +22,7 @@ package io.spine.users.server.signin;
 
 import io.spine.core.UserId;
 import io.spine.server.procman.ProcessManagerRepository;
-import io.spine.users.server.IdentityProviderBridgeFactory;
+import io.spine.users.server.DirectoryFactory;
 import io.spine.users.server.user.UserPartRepository;
 import io.spine.users.signin.SignIn;
 
@@ -34,9 +34,9 @@ import io.spine.users.signin.SignIn;
 public class SignInPmRepository extends ProcessManagerRepository<UserId, SignInPm, SignIn> {
 
     private final UserPartRepository userRepository;
-    private final IdentityProviderBridgeFactory identityProviderFactory;
+    private final DirectoryFactory identityProviderFactory;
 
-    public SignInPmRepository(IdentityProviderBridgeFactory identityProviderFactory,
+    public SignInPmRepository(DirectoryFactory identityProviderFactory,
                               UserPartRepository userRepository) {
         super();
         this.identityProviderFactory = identityProviderFactory;
@@ -47,7 +47,7 @@ public class SignInPmRepository extends ProcessManagerRepository<UserId, SignInP
     protected SignInPm findOrCreate(UserId id) {
         SignInPm processManager = super.findOrCreate(id);
         processManager.setUserRepository(userRepository);
-        processManager.setIdentityProviderFactory(identityProviderFactory);
+        processManager.setDirectoryFactory(identityProviderFactory);
         return processManager;
     }
 }

--- a/users/src/main/java/io/spine/users/server/user/UserPart.java
+++ b/users/src/main/java/io/spine/users/server/user/UserPart.java
@@ -372,9 +372,9 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
         return identity -> {
             boolean idMatches = identity.getUserId()
                                         .equals(command.getUserId());
-            boolean providerMatches = identity.getProviderId()
-                                              .equals(command.getProviderId());
-            return idMatches && providerMatches;
+            boolean directoryMatches = identity.getDirectoryId()
+                                               .equals(command.getDirectoryId());
+            return idMatches && directoryMatches;
         };
     }
 
@@ -383,7 +383,7 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
         return IdentityDoesNotExist
                 .newBuilder()
                 .setId(command.getId())
-                .setProviderId(command.getProviderId())
+                .setDirectoryId(command.getDirectoryId())
                 .setUserId(command.getUserId())
                 .build();
     }

--- a/users/src/main/proto/spine/users/identifiers.proto
+++ b/users/src/main/proto/spine/users/identifiers.proto
@@ -64,11 +64,11 @@ message OrgUnitId {
     string value = 1;
 }
 
-// A string-based identifier of an authentication identity provider.
+// A string-based identifier of a directory service.
 //
 // For example, "google.com", "active-directory.mycompany.co.uk".
 //
-message IdentityProviderId {
+message DirectoryId {
 
     string value = 1;
 }

--- a/users/src/main/proto/spine/users/identifiers.proto
+++ b/users/src/main/proto/spine/users/identifiers.proto
@@ -64,7 +64,7 @@ message OrgUnitId {
     string value = 1;
 }
 
-// A string-based identifier of a directory service.
+// A string-based identifier of a user directory.
 //
 // For example, "google.com", "active-directory.mycompany.co.uk".
 //

--- a/users/src/main/proto/spine/users/person_profile.proto
+++ b/users/src/main/proto/spine/users/person_profile.proto
@@ -38,7 +38,7 @@ import "spine/people/person_name.proto";
 //
 // This message is used for displaying user information on UI.
 //
-// Contents of this message are usually obtained from authentication providers.
+// Contents of this message are usually obtained from a directory service.
 //
 message PersonProfile {
 

--- a/users/src/main/proto/spine/users/person_profile.proto
+++ b/users/src/main/proto/spine/users/person_profile.proto
@@ -38,7 +38,7 @@ import "spine/people/person_name.proto";
 //
 // This message is used for displaying user information on UI.
 //
-// Contents of this message are usually obtained from a directory service.
+// Contents of this message are usually obtained from a user directory.
 //
 message PersonProfile {
 

--- a/users/src/main/proto/spine/users/signin/sign_in.proto
+++ b/users/src/main/proto/spine/users/signin/sign_in.proto
@@ -47,10 +47,9 @@ import "spine/users/signin/values.proto";
 // To sign a user in, the process manager ensures the following:
 //
 // 1. a user directory is aware of the given identity;
-// 2. a user directory authorize the user to sign in (e.g. the opposite would be if the user
-//    account was suspended);
-// 3. the given identity is associated with the user (please see `AddAuthIdentity`
-//    command).
+// 2. a user directory authorizes the user to sign in (the opposite would be if the user account
+//    was suspended);
+// 3. the given identity is associated with the user (see `AddAuthIdentity` command).
 //
 // If one of the checks fails, the process is completed immediately with `SignInFailed` event.
 //

--- a/users/src/main/proto/spine/users/signin/sign_in.proto
+++ b/users/src/main/proto/spine/users/signin/sign_in.proto
@@ -34,7 +34,7 @@ import "spine/core/user_id.proto";
 import "spine/users/user/identity.proto";
 import "spine/users/signin/values.proto";
 
-// The process of a user sign-in..
+// The process of a user sign-in.
 //
 // This process manager covers a straightforward sign-in scenario:
 //
@@ -46,8 +46,8 @@ import "spine/users/signin/values.proto";
 //
 // To sign a user in, the process manager ensures the following:
 //
-// 1. an identity provider is aware of the given identity;
-// 2. an identity provider authorize the user to sign in (e.g. the opposite would be if the user
+// 1. a directory service is aware of the given identity;
+// 2. a directory service authorize the user to sign in (e.g. the opposite would be if the user
 //    account was suspended);
 // 3. the given identity is associated with the user (please see `AddAuthIdentity`
 //    command).

--- a/users/src/main/proto/spine/users/signin/sign_in.proto
+++ b/users/src/main/proto/spine/users/signin/sign_in.proto
@@ -47,7 +47,7 @@ import "spine/users/signin/values.proto";
 // To sign a user in, the process manager ensures the following:
 //
 // 1. a user directory is aware of the given identity;
-// 2. a user directory authorizes the user to sign in (the opposite would be if the user account
+// 2. a user directory authorizes the user to sign-in (the opposite would be if the user account
 //    was suspended);
 // 3. the given identity is associated with the user (see `AddAuthIdentity` command).
 //
@@ -61,7 +61,7 @@ message SignIn {
     // The current status of the process.
     Status status = 2;
 
-    // A user identity used to sign in.
+    // A user identity used to sign-in.
     Identity identity = 3 [(required) = true];
 
     // A reason why the process failed, if applicable.

--- a/users/src/main/proto/spine/users/signin/sign_in.proto
+++ b/users/src/main/proto/spine/users/signin/sign_in.proto
@@ -46,8 +46,8 @@ import "spine/users/signin/values.proto";
 //
 // To sign a user in, the process manager ensures the following:
 //
-// 1. a directory service is aware of the given identity;
-// 2. a directory service authorize the user to sign in (e.g. the opposite would be if the user
+// 1. a user directory is aware of the given identity;
+// 2. a user directory authorize the user to sign in (e.g. the opposite would be if the user
 //    account was suspended);
 // 3. the given identity is associated with the user (please see `AddAuthIdentity`
 //    command).

--- a/users/src/main/proto/spine/users/signin/values.proto
+++ b/users/src/main/proto/spine/users/signin/values.proto
@@ -37,7 +37,7 @@ enum SignInFailureReason {
     // Default value.
     SIFR_UNDEFINED = 0;
 
-    // Indicates that a directory service is not aware of the given identity or the identity
+    // Indicates that a user directory is not aware of the given identity or the identity
     // is not associated with the given `User`.
     //
     UNKNOWN_IDENTITY = 1;
@@ -47,6 +47,6 @@ enum SignInFailureReason {
     //
     UNSUPPORTED_IDENTITY = 2;
 
-    // Indicates that this identity is not authorized to sign-in by the directory service.
+    // Indicates that this identity is not authorized to sign-in by the user directory.
     SIGN_IN_NOT_AUTHORIZED = 3;
 }

--- a/users/src/main/proto/spine/users/signin/values.proto
+++ b/users/src/main/proto/spine/users/signin/values.proto
@@ -37,16 +37,16 @@ enum SignInFailureReason {
     // Default value.
     SIFR_UNDEFINED = 0;
 
-    // Indicates that an identity provider is not aware of the given identity or the identity
+    // Indicates that a directory service is not aware of the given identity or the identity
     // is not associated with the given `User`.
     //
     UNKNOWN_IDENTITY = 1;
 
-    // Indicates that the requested identity is not supported and the corresponding identity
-    // provider can't be found.
+    // Indicates that the requested identity is not supported and the corresponding directory
+    // can't be found.
     //
     UNSUPPORTED_IDENTITY = 2;
 
-    // Indicates that this identity is not authorized to sign-in by the identity provider.
+    // Indicates that this identity is not authorized to sign-in by the directory service.
     SIGN_IN_NOT_AUTHORIZED = 3;
 }

--- a/users/src/main/proto/spine/users/user/commands.proto
+++ b/users/src/main/proto/spine/users/user/commands.proto
@@ -176,7 +176,7 @@ message RemoveSecondaryIdentity {
     string user_id = 2 [(required) = true];
 
     // A unique identifier of the authentication provider.
-    IdentityProviderId provider_id = 3 [(required) = true];
+    DirectoryId provider_id = 3 [(required) = true];
 }
 
 // Changes the primary identity.

--- a/users/src/main/proto/spine/users/user/commands.proto
+++ b/users/src/main/proto/spine/users/user/commands.proto
@@ -172,10 +172,10 @@ message RemoveSecondaryIdentity {
 
     core.UserId id = 1;
 
-    // A user identifier as specified by the directory service.
+    // A user identifier as specified by the user directory.
     string user_id = 2 [(required) = true];
 
-    // A unique identifier of the directory service.
+    // A unique identifier of the user directory.
     DirectoryId directory_id = 3 [(required) = true];
 }
 

--- a/users/src/main/proto/spine/users/user/commands.proto
+++ b/users/src/main/proto/spine/users/user/commands.proto
@@ -172,11 +172,11 @@ message RemoveSecondaryIdentity {
 
     core.UserId id = 1;
 
-    // A user identifier as specified by the authentication provider.
+    // A user identifier as specified by the directory service.
     string user_id = 2 [(required) = true];
 
-    // A unique identifier of the authentication provider.
-    DirectoryId provider_id = 3 [(required) = true];
+    // A unique identifier of the directory service.
+    DirectoryId directory_id = 3 [(required) = true];
 }
 
 // Changes the primary identity.

--- a/users/src/main/proto/spine/users/user/identity.proto
+++ b/users/src/main/proto/spine/users/user/identity.proto
@@ -38,10 +38,10 @@ import "spine/users/identifiers.proto";
 //
 message Identity {
 
-    // A user identifier as specified by the directory service.
+    // A user identifier as specified by the user directory.
     string user_id = 1 [(required) = true];
 
-    // A unique identifier of the directory service.
+    // A unique identifier of the user directory.
     DirectoryId directory_id = 2 [(required) = true];
 
     // A user's name to display on UI.

--- a/users/src/main/proto/spine/users/user/identity.proto
+++ b/users/src/main/proto/spine/users/user/identity.proto
@@ -38,11 +38,11 @@ import "spine/users/identifiers.proto";
 //
 message Identity {
 
-    // A user identifier as specified by the authentication provider.
+    // A user identifier as specified by the directory service.
     string user_id = 1 [(required) = true];
 
-    // A unique identifier of the authentication provider.
-    DirectoryId provider_id = 2 [(required) = true];
+    // A unique identifier of the directory service.
+    DirectoryId directory_id = 2 [(required) = true];
 
     // A user's name to display on UI.
     string display_name = 3 [(required) = true];

--- a/users/src/main/proto/spine/users/user/identity.proto
+++ b/users/src/main/proto/spine/users/user/identity.proto
@@ -42,7 +42,7 @@ message Identity {
     string user_id = 1 [(required) = true];
 
     // A unique identifier of the authentication provider.
-    IdentityProviderId provider_id = 2 [(required) = true];
+    DirectoryId provider_id = 2 [(required) = true];
 
     // A user's name to display on UI.
     string display_name = 3 [(required) = true];

--- a/users/src/main/proto/spine/users/user/rejections.proto
+++ b/users/src/main/proto/spine/users/user/rejections.proto
@@ -39,10 +39,10 @@ message IdentityDoesNotExist {
 
     core.UserId id = 1;
 
-    // A user identity that wasn't found.
-    DirectoryId provider_id = 2 [(required) = true];
+    // A unique identifier of the directory service.
+    DirectoryId directory_id = 2 [(required) = true];
 
-    // A unique identifier of the authentication provider.
+    // A user identity that wasn't found.
     string user_id = 3 [(required) = true];
 }
 

--- a/users/src/main/proto/spine/users/user/rejections.proto
+++ b/users/src/main/proto/spine/users/user/rejections.proto
@@ -40,7 +40,7 @@ message IdentityDoesNotExist {
     core.UserId id = 1;
 
     // A user identity that wasn't found.
-    IdentityProviderId provider_id = 2 [(required) = true];
+    DirectoryId provider_id = 2 [(required) = true];
 
     // A unique identifier of the authentication provider.
     string user_id = 3 [(required) = true];

--- a/users/src/main/proto/spine/users/user/rejections.proto
+++ b/users/src/main/proto/spine/users/user/rejections.proto
@@ -39,7 +39,7 @@ message IdentityDoesNotExist {
 
     core.UserId id = 1;
 
-    // A unique identifier of the directory service.
+    // A unique identifier of the user directory.
     DirectoryId directory_id = 2 [(required) = true];
 
     // A user identity that wasn't found.

--- a/users/src/main/proto/spine/users/user/user.proto
+++ b/users/src/main/proto/spine/users/user/user.proto
@@ -85,7 +85,7 @@ message User {
 
     // The primary user identity.
     //
-    // The primary identity and its provider (i.e. the directory service to which the identity
+    // The primary identity and its provider (i.e. the user directory to which the identity
     // belongs) are used as a single source of truth about a user:
     //  - to get a user profile;
     //  - to check whether a user account is active;
@@ -118,7 +118,7 @@ message User {
         // A user is active and ready to work.
         ACTIVE = 2;
 
-        // A user is suspended by a directory service.
+        // A user is suspended by a user directory.
         SUSPENDED = 3;
 
         // A user is external and its status is unknown.

--- a/users/src/main/proto/spine/users/user/user.proto
+++ b/users/src/main/proto/spine/users/user/user.proto
@@ -85,7 +85,8 @@ message User {
 
     // The primary user identity.
     //
-    // The primary identity and its provider are used as a single source of truth about a user:
+    // The primary identity and its provider (i.e. the directory service to which the identity
+    // belongs) are used as a single source of truth about a user:
     //  - to get a user profile;
     //  - to check whether a user account is active;
     //  - etc.
@@ -117,7 +118,7 @@ message User {
         // A user is active and ready to work.
         ACTIVE = 2;
 
-        // A user is suspended by an identity provider.
+        // A user is suspended by a directory service.
         SUSPENDED = 3;
 
         // A user is external and its status is unknown.

--- a/users/src/test/java/io/spine/users/server/signin/SignInPmCommandOnCommandTest.java
+++ b/users/src/test/java/io/spine/users/server/signin/SignInPmCommandOnCommandTest.java
@@ -24,7 +24,7 @@ import io.spine.base.CommandMessage;
 import io.spine.core.UserId;
 import io.spine.server.entity.Repository;
 import io.spine.testing.server.procman.PmCommandOnCommandTest;
-import io.spine.users.server.IdentityProviderBridgeFactory;
+import io.spine.users.server.DirectoryFactory;
 import io.spine.users.server.user.UserPartRepository;
 import io.spine.users.signin.SignIn;
 
@@ -45,7 +45,7 @@ abstract class SignInPmCommandOnCommandTest<C extends CommandMessage>
 
     @Override
     protected Repository<UserId, SignInPm> createRepository() {
-        return new SignInPmRepository(mock(IdentityProviderBridgeFactory.class),
+        return new SignInPmRepository(mock(DirectoryFactory.class),
                                       mock(UserPartRepository.class));
     }
 }

--- a/users/src/test/java/io/spine/users/server/signin/SignInPmCommandTest.java
+++ b/users/src/test/java/io/spine/users/server/signin/SignInPmCommandTest.java
@@ -24,7 +24,7 @@ import io.spine.base.CommandMessage;
 import io.spine.core.UserId;
 import io.spine.server.entity.Repository;
 import io.spine.testing.server.procman.PmCommandTest;
-import io.spine.users.server.IdentityProviderBridgeFactory;
+import io.spine.users.server.DirectoryFactory;
 import io.spine.users.server.user.UserPartRepository;
 import io.spine.users.signin.SignIn;
 
@@ -45,7 +45,7 @@ abstract class SignInPmCommandTest<C extends CommandMessage>
 
     @Override
     protected Repository<UserId, SignInPm> createRepository() {
-        return new SignInPmRepository(mock(IdentityProviderBridgeFactory.class),
+        return new SignInPmRepository(mock(DirectoryFactory.class),
                                       mock(UserPartRepository.class));
     }
 }

--- a/users/src/test/java/io/spine/users/server/signin/SignUserInCommandTest.java
+++ b/users/src/test/java/io/spine/users/server/signin/SignUserInCommandTest.java
@@ -120,7 +120,7 @@ class SignUserInCommandTest extends SignInPmCommandOnCommandTest<SignUserIn> {
     }
 
     @Test
-    @DisplayName("fail if identity provider is not aware of given identity")
+    @DisplayName("fail if directory is not aware of given identity")
     void failIfUnknownIdentity() {
         SignInPm emptyProcMan = createEmptyProcMan(entityId());
         emptyProcMan.setUserRepository(noIdentityUserRepo());
@@ -133,8 +133,8 @@ class SignUserInCommandTest extends SignInPmCommandOnCommandTest<SignUserIn> {
     }
 
     @Test
-    @DisplayName("fail if there is no identity provider")
-    void failIfNoProvider() {
+    @DisplayName("fail if there is no directory")
+    void failIfNoDirectory() {
         SignInPm emptyProcMan = withIdentity(entityId(), directoryId("invalid"));
         emptyProcMan.setUserRepository(noIdentityUserRepo());
         emptyProcMan.setDirectoryFactory(mockEmptyDirectoryFactory());

--- a/users/src/test/java/io/spine/users/server/signin/SignUserInCommandTest.java
+++ b/users/src/test/java/io/spine/users/server/signin/SignUserInCommandTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.users.server.signin.TestProcManFactory.createEmptyProcMan;
-import static io.spine.users.server.signin.TestProcManFactory.identityProviderId;
+import static io.spine.users.server.signin.TestProcManFactory.directoryId;
 import static io.spine.users.server.signin.TestProcManFactory.withIdentity;
 import static io.spine.users.server.signin.given.SignInTestCommands.signInCommand;
 import static io.spine.users.server.signin.given.SignInTestEnv.mockActiveDirectory;
@@ -135,7 +135,7 @@ class SignUserInCommandTest extends SignInPmCommandOnCommandTest<SignUserIn> {
     @Test
     @DisplayName("fail if there is no identity provider")
     void failIfNoProvider() {
-        SignInPm emptyProcMan = withIdentity(entityId(), identityProviderId("invalid"));
+        SignInPm emptyProcMan = withIdentity(entityId(), directoryId("invalid"));
         emptyProcMan.setUserRepository(noIdentityUserRepo());
         emptyProcMan.setDirectoryFactory(mockEmptyDirectoryFactory());
         expectThat(emptyProcMan).producesCommand(FinishSignIn.class, command -> {

--- a/users/src/test/java/io/spine/users/server/signin/SignUserInCommandTest.java
+++ b/users/src/test/java/io/spine/users/server/signin/SignUserInCommandTest.java
@@ -31,10 +31,10 @@ import static io.spine.users.server.signin.TestProcManFactory.createEmptyProcMan
 import static io.spine.users.server.signin.TestProcManFactory.identityProviderId;
 import static io.spine.users.server.signin.TestProcManFactory.withIdentity;
 import static io.spine.users.server.signin.given.SignInTestCommands.signInCommand;
-import static io.spine.users.server.signin.given.SignInTestEnv.mockActiveIdentityProvider;
-import static io.spine.users.server.signin.given.SignInTestEnv.mockEmptyIdentityProvider;
-import static io.spine.users.server.signin.given.SignInTestEnv.mockEmptyProviderFactory;
-import static io.spine.users.server.signin.given.SignInTestEnv.mockSuspendedIdentityProvider;
+import static io.spine.users.server.signin.given.SignInTestEnv.mockActiveDirectory;
+import static io.spine.users.server.signin.given.SignInTestEnv.mockEmptyDirectory;
+import static io.spine.users.server.signin.given.SignInTestEnv.mockEmptyDirectoryFactory;
+import static io.spine.users.server.signin.given.SignInTestEnv.mockSuspendedDirectory;
 import static io.spine.users.server.signin.given.SignInTestEnv.noIdentityUserRepo;
 import static io.spine.users.server.signin.given.SignInTestEnv.nonEmptyUserRepo;
 import static io.spine.users.signin.SignIn.Status.AWAITING_USER_AGGREGATE_CREATION;
@@ -57,7 +57,7 @@ class SignUserInCommandTest extends SignInPmCommandOnCommandTest<SignUserIn> {
     void initialize() {
         SignInPm emptyProcMan = createEmptyProcMan(entityId());
         emptyProcMan.setUserRepository(SignInTestEnv.emptyUserRepo());
-        emptyProcMan.setIdentityProviderFactory(mockActiveIdentityProvider());
+        emptyProcMan.setDirectoryFactory(mockActiveDirectory());
         expectThat(emptyProcMan).hasState(state -> {
             assertEquals(message().getId(), state.getId());
             assertEquals(message().getIdentity(), state.getIdentity());
@@ -69,7 +69,7 @@ class SignUserInCommandTest extends SignInPmCommandOnCommandTest<SignUserIn> {
     void createUser() {
         SignInPm emptyProcMan = createEmptyProcMan(entityId());
         emptyProcMan.setUserRepository(SignInTestEnv.emptyUserRepo());
-        emptyProcMan.setIdentityProviderFactory(mockActiveIdentityProvider());
+        emptyProcMan.setDirectoryFactory(mockActiveDirectory());
         expectThat(emptyProcMan)
                 .producesCommand(CreateUser.class, command -> {
                     assertEquals(message().getId(), command.getId());
@@ -84,7 +84,7 @@ class SignUserInCommandTest extends SignInPmCommandOnCommandTest<SignUserIn> {
     void finishProcess() {
         SignInPm emptyProcMan = createEmptyProcMan(entityId());
         emptyProcMan.setUserRepository(nonEmptyUserRepo());
-        emptyProcMan.setIdentityProviderFactory(mockActiveIdentityProvider());
+        emptyProcMan.setDirectoryFactory(mockActiveDirectory());
 
         expectThat(emptyProcMan)
                 .producesCommand(FinishSignIn.class,
@@ -97,7 +97,7 @@ class SignUserInCommandTest extends SignInPmCommandOnCommandTest<SignUserIn> {
     void failProcess() {
         SignInPm emptyProcMan = createEmptyProcMan(entityId());
         emptyProcMan.setUserRepository(nonEmptyUserRepo());
-        emptyProcMan.setIdentityProviderFactory(mockSuspendedIdentityProvider());
+        emptyProcMan.setDirectoryFactory(mockSuspendedDirectory());
 
         expectThat(emptyProcMan).producesCommand(FinishSignIn.class, command -> {
             assertEquals(message().getId(), command.getId());
@@ -111,7 +111,7 @@ class SignUserInCommandTest extends SignInPmCommandOnCommandTest<SignUserIn> {
     void failIfNoIdentity() {
         SignInPm emptyProcMan = createEmptyProcMan(entityId());
         emptyProcMan.setUserRepository(noIdentityUserRepo());
-        emptyProcMan.setIdentityProviderFactory(mockActiveIdentityProvider());
+        emptyProcMan.setDirectoryFactory(mockActiveDirectory());
         expectThat(emptyProcMan).producesCommand(FinishSignIn.class, command -> {
             assertEquals(message().getId(), command.getId());
             assertFalse(command.getSuccessful());
@@ -124,7 +124,7 @@ class SignUserInCommandTest extends SignInPmCommandOnCommandTest<SignUserIn> {
     void failIfUnknownIdentity() {
         SignInPm emptyProcMan = createEmptyProcMan(entityId());
         emptyProcMan.setUserRepository(noIdentityUserRepo());
-        emptyProcMan.setIdentityProviderFactory(mockEmptyIdentityProvider());
+        emptyProcMan.setDirectoryFactory(mockEmptyDirectory());
         expectThat(emptyProcMan).producesCommand(FinishSignIn.class, command -> {
             assertEquals(message().getId(), command.getId());
             assertFalse(command.getSuccessful());
@@ -137,7 +137,7 @@ class SignUserInCommandTest extends SignInPmCommandOnCommandTest<SignUserIn> {
     void failIfNoProvider() {
         SignInPm emptyProcMan = withIdentity(entityId(), identityProviderId("invalid"));
         emptyProcMan.setUserRepository(noIdentityUserRepo());
-        emptyProcMan.setIdentityProviderFactory(mockEmptyProviderFactory());
+        emptyProcMan.setDirectoryFactory(mockEmptyDirectoryFactory());
         expectThat(emptyProcMan).producesCommand(FinishSignIn.class, command -> {
             assertEquals(message().getId(), command.getId());
             assertFalse(command.getSuccessful());

--- a/users/src/test/java/io/spine/users/server/signin/SignUserOutCommandTest.java
+++ b/users/src/test/java/io/spine/users/server/signin/SignUserOutCommandTest.java
@@ -26,7 +26,7 @@ import io.spine.users.signin.event.SignOutCompleted;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.users.server.signin.TestProcManFactory.identityProviderId;
+import static io.spine.users.server.signin.TestProcManFactory.directoryId;
 import static io.spine.users.server.signin.TestProcManFactory.withIdentity;
 import static io.spine.users.server.signin.given.SignInTestEnv.userId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,7 +41,7 @@ class SignUserOutCommandTest extends SignInPmCommandTest<SignUserOut> {
     @Test
     @DisplayName("generate SignOutCompleted event")
     void failProcess() {
-        SignInPm emptyProcMan = withIdentity(entityId(), identityProviderId("google.com"));
+        SignInPm emptyProcMan = withIdentity(entityId(), directoryId("google.com"));
 
         expectThat(emptyProcMan)
                 .producesEvent(SignOutCompleted.class,

--- a/users/src/test/java/io/spine/users/server/signin/TestProcManFactory.java
+++ b/users/src/test/java/io/spine/users/server/signin/TestProcManFactory.java
@@ -22,7 +22,7 @@ package io.spine.users.server.signin;
 
 import io.spine.core.UserId;
 import io.spine.testing.server.entity.given.Given;
-import io.spine.users.IdentityProviderId;
+import io.spine.users.DirectoryId;
 import io.spine.users.server.user.UserPart;
 import io.spine.users.signin.SignIn;
 import io.spine.users.signin.SignIn.Status;
@@ -61,8 +61,8 @@ final class TestProcManFactory {
                     .build();
     }
 
-    static SignInPm withIdentity(UserId id, IdentityProviderId identityProviderId) {
-        Identity identity = identity(id.getValue(), identityProviderId, "Test User");
+    static SignInPm withIdentity(UserId id, DirectoryId directoryId) {
+        Identity identity = identity(id.getValue(), directoryId, "Test User");
         SignIn state = signIn(id, identity, SIS_UNKNOWN);
         return Given.processManagerOfClass(SignInPm.class)
                     .withId(id)
@@ -79,8 +79,8 @@ final class TestProcManFactory {
                 .build();
     }
 
-    static IdentityProviderId identityProviderId(String id) {
-        return IdentityProviderId
+    static DirectoryId directoryId(String id) {
+        return DirectoryId
                 .newBuilder()
                 .setValue(id)
                 .build();

--- a/users/src/test/java/io/spine/users/server/signin/given/SignInTestEnv.java
+++ b/users/src/test/java/io/spine/users/server/signin/given/SignInTestEnv.java
@@ -127,11 +127,11 @@ public final class SignInTestEnv {
     }
 
     public static Identity identity() {
-        return identity("123543", googleProviderId(), "j.s@google.com");
+        return identity("123543", googleDirectoryId(), "j.s@google.com");
     }
 
     public static Identity secondaryIdentity() {
-        return identity("6987", googleProviderId(), "s.j@google.com");
+        return identity("6987", googleDirectoryId(), "s.j@google.com");
     }
 
     public static Identity identity(String id, DirectoryId directoryId, String name) {
@@ -139,7 +139,7 @@ public final class SignInTestEnv {
                 .newBuilder()
                 .setUserId(id)
                 .setDisplayName(name)
-                .setProviderId(directoryId)
+                .setDirectoryId(directoryId)
                 .build();
     }
 
@@ -158,7 +158,7 @@ public final class SignInTestEnv {
                                     .build();
     }
 
-    static DirectoryId googleProviderId() {
+    static DirectoryId googleDirectoryId() {
         return DirectoryIdVBuilder.newBuilder()
                                   .setValue("gmail.com")
                                   .build();
@@ -226,7 +226,7 @@ public final class SignInTestEnv {
     }
 
     /**
-     * A factory that always returns a single identity provider.
+     * A factory that always returns a single directory service.
      */
     static class TestDirectoryFactory implements DirectoryFactory {
 

--- a/users/src/test/java/io/spine/users/server/signin/given/SignInTestEnv.java
+++ b/users/src/test/java/io/spine/users/server/signin/given/SignInTestEnv.java
@@ -226,7 +226,7 @@ public final class SignInTestEnv {
     }
 
     /**
-     * A factory that always returns a single directory service.
+     * A factory that always returns a single user directory.
      */
     static class TestDirectoryFactory implements DirectoryFactory {
 

--- a/users/src/test/java/io/spine/users/server/signin/given/SignInTestEnv.java
+++ b/users/src/test/java/io/spine/users/server/signin/given/SignInTestEnv.java
@@ -26,8 +26,8 @@ import io.spine.net.EmailAddressVBuilder;
 import io.spine.people.PersonName;
 import io.spine.people.PersonNameVBuilder;
 import io.spine.testing.core.given.GivenUserId;
-import io.spine.users.IdentityProviderId;
-import io.spine.users.IdentityProviderIdVBuilder;
+import io.spine.users.DirectoryId;
+import io.spine.users.DirectoryIdVBuilder;
 import io.spine.users.OrganizationId;
 import io.spine.users.OrganizationIdVBuilder;
 import io.spine.users.OrganizationOrUnit;
@@ -134,12 +134,12 @@ public final class SignInTestEnv {
         return identity("6987", googleProviderId(), "s.j@google.com");
     }
 
-    public static Identity identity(String id, IdentityProviderId identityProviderId, String name) {
+    public static Identity identity(String id, DirectoryId directoryId, String name) {
         return IdentityVBuilder
                 .newBuilder()
                 .setUserId(id)
                 .setDisplayName(name)
-                .setProviderId(identityProviderId)
+                .setProviderId(directoryId)
                 .build();
     }
 
@@ -158,10 +158,10 @@ public final class SignInTestEnv {
                                     .build();
     }
 
-    static IdentityProviderId googleProviderId() {
-        return IdentityProviderIdVBuilder.newBuilder()
-                                         .setValue("gmail.com")
-                                         .build();
+    static DirectoryId googleProviderId() {
+        return DirectoryIdVBuilder.newBuilder()
+                                  .setValue("gmail.com")
+                                  .build();
     }
 
     private static UserPart normalUserPart() {
@@ -238,7 +238,7 @@ public final class SignInTestEnv {
         }
 
         @Override
-        public Optional<Directory> get(IdentityProviderId id) {
+        public Optional<Directory> get(DirectoryId id) {
             return ofNullable(directory);
         }
     }

--- a/users/src/test/java/io/spine/users/server/signin/given/SignInTestEnv.java
+++ b/users/src/test/java/io/spine/users/server/signin/given/SignInTestEnv.java
@@ -35,8 +35,8 @@ import io.spine.users.OrganizationOrUnitVBuilder;
 import io.spine.users.PersonProfile;
 import io.spine.users.PersonProfileVBuilder;
 import io.spine.users.RoleId;
-import io.spine.users.server.IdentityProviderBridge;
-import io.spine.users.server.IdentityProviderBridgeFactory;
+import io.spine.users.server.Directory;
+import io.spine.users.server.DirectoryFactory;
 import io.spine.users.server.signin.SignInPm;
 import io.spine.users.server.user.UserPart;
 import io.spine.users.server.user.UserPartRepository;
@@ -98,32 +98,32 @@ public final class SignInTestEnv {
         return mock;
     }
 
-    public static IdentityProviderBridgeFactory mockActiveIdentityProvider() {
-        IdentityProviderBridge mock = mock(IdentityProviderBridge.class);
+    public static DirectoryFactory mockActiveDirectory() {
+        Directory mock = mock(Directory.class);
         when(mock.hasIdentity(any())).thenReturn(true);
         when(mock.isSignInAllowed(any())).thenReturn(true);
         when(mock.fetchProfile(any())).thenReturn(profile());
-        return new TestIdentityProviderFactory(mock);
+        return new TestDirectoryFactory(mock);
     }
 
-    public static IdentityProviderBridgeFactory mockSuspendedIdentityProvider() {
-        IdentityProviderBridge mock = mock(IdentityProviderBridge.class);
+    public static DirectoryFactory mockSuspendedDirectory() {
+        Directory mock = mock(Directory.class);
         when(mock.hasIdentity(any())).thenReturn(true);
         when(mock.isSignInAllowed(any())).thenReturn(false);
         when(mock.fetchProfile(any())).thenReturn(profile());
-        return new TestIdentityProviderFactory(mock);
+        return new TestDirectoryFactory(mock);
     }
 
-    public static IdentityProviderBridgeFactory mockEmptyIdentityProvider() {
-        IdentityProviderBridge mock = mock(IdentityProviderBridge.class);
+    public static DirectoryFactory mockEmptyDirectory() {
+        Directory mock = mock(Directory.class);
         when(mock.hasIdentity(any())).thenReturn(false);
         when(mock.isSignInAllowed(any())).thenReturn(false);
         when(mock.fetchProfile(any())).thenReturn(PersonProfile.getDefaultInstance());
-        return new TestIdentityProviderFactory(mock);
+        return new TestDirectoryFactory(mock);
     }
 
-    public static IdentityProviderBridgeFactory mockEmptyProviderFactory() {
-        return new TestIdentityProviderFactory(null);
+    public static DirectoryFactory mockEmptyDirectoryFactory() {
+        return new TestDirectoryFactory(null);
     }
 
     public static Identity identity() {
@@ -228,18 +228,18 @@ public final class SignInTestEnv {
     /**
      * A factory that always returns a single identity provider.
      */
-    static class TestIdentityProviderFactory extends IdentityProviderBridgeFactory {
+    static class TestDirectoryFactory implements DirectoryFactory {
 
-        private final IdentityProviderBridge provider;
+        private final Directory directory;
 
-        private TestIdentityProviderFactory(IdentityProviderBridge provider) {
+        private TestDirectoryFactory(Directory directory) {
             super();
-            this.provider = provider;
+            this.directory = directory;
         }
 
         @Override
-        public Optional<IdentityProviderBridge> get(IdentityProviderId id) {
-            return ofNullable(provider);
+        public Optional<Directory> get(IdentityProviderId id) {
+            return ofNullable(directory);
         }
     }
 }

--- a/users/src/test/java/io/spine/users/server/signin/given/package-info.java
+++ b/users/src/test/java/io/spine/users/server/signin/given/package-info.java
@@ -18,26 +18,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.users.server;
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.users.server.signin.given;
 
-import io.spine.users.IdentityProviderId;
+import com.google.errorprone.annotations.CheckReturnValue;
 
-import java.util.Optional;
-
-/**
- * A factory for creating {@link IdentityProviderBridge identity provider bridges}.
- *
- * @author Vladyslav Lubenskyi
- */
-public abstract class IdentityProviderBridgeFactory {
-
-    /**
-     * Obtains or creates a {@link IdentityProviderBridge bridge} to communicate with
-     * an authentication identity provider.
-     *
-     * @param id a unique identifier of the identity provider
-     * @return {@link IdentityProviderBridge} if the requested identity provider is supported,
-     * {@code Optional.empty()} otherwise
-     */
-    public abstract Optional<IdentityProviderBridge> get(IdentityProviderId id);
-}
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/users/src/test/java/io/spine/users/server/user/RemoveAuthIdentityTest.java
+++ b/users/src/test/java/io/spine/users/server/user/RemoveAuthIdentityTest.java
@@ -45,7 +45,7 @@ class RemoveAuthIdentityTest extends UserPartCommandTest<RemoveSecondaryIdentity
         expectThat(aggregate).producesEvent(SecondaryIdentityRemoved.class, event -> {
             assertEquals(message().getId(), event.getId());
             Identity eventIdentity = event.getIdentity();
-            assertEquals(message().getProviderId(), eventIdentity.getProviderId());
+            assertEquals(message().getDirectoryId(), eventIdentity.getDirectoryId());
             assertEquals(message().getUserId(), eventIdentity.getUserId());
         });
     }

--- a/users/src/test/java/io/spine/users/server/user/given/UserTestCommands.java
+++ b/users/src/test/java/io/spine/users/server/user/given/UserTestCommands.java
@@ -145,7 +145,7 @@ public class UserTestCommands {
         Identity identity = googleIdentity();
         return RemoveSecondaryIdentityVBuilder.newBuilder()
                                               .setId(id)
-                                              .setProviderId(identity.getProviderId())
+                                              .setDirectoryId(identity.getDirectoryId())
                                               .setUserId(identity.getUserId())
                                               .build();
     }

--- a/users/src/test/java/io/spine/users/server/user/given/UserTestEnv.java
+++ b/users/src/test/java/io/spine/users/server/user/given/UserTestEnv.java
@@ -28,8 +28,8 @@ import io.spine.people.PersonNameVBuilder;
 import io.spine.testing.core.given.GivenUserId;
 import io.spine.users.GroupId;
 import io.spine.users.GroupIdVBuilder;
-import io.spine.users.IdentityProviderId;
-import io.spine.users.IdentityProviderIdVBuilder;
+import io.spine.users.DirectoryId;
+import io.spine.users.DirectoryIdVBuilder;
 import io.spine.users.OrgUnitId;
 import io.spine.users.OrgUnitIdVBuilder;
 import io.spine.users.OrganizationId;
@@ -127,14 +127,14 @@ public class UserTestEnv {
         return roleId(userOrgEntity(), "editor_role");
     }
 
-    private static IdentityProviderId googleProviderId() {
-        return IdentityProviderIdVBuilder.newBuilder()
+    private static DirectoryId googleProviderId() {
+        return DirectoryIdVBuilder.newBuilder()
                                          .setValue("gmail.com")
                                          .build();
     }
 
-    private static IdentityProviderId githubPoviderId() {
-        return IdentityProviderIdVBuilder.newBuilder()
+    private static DirectoryId githubPoviderId() {
+        return DirectoryIdVBuilder.newBuilder()
                                          .setValue("github.com")
                                          .build();
     }

--- a/users/src/test/java/io/spine/users/server/user/given/UserTestEnv.java
+++ b/users/src/test/java/io/spine/users/server/user/given/UserTestEnv.java
@@ -106,7 +106,7 @@ public class UserTestEnv {
     public static Identity googleIdentity() {
         return IdentityVBuilder.newBuilder()
                                .setDisplayName("j.s@google.com")
-                               .setProviderId(googleProviderId())
+                               .setDirectoryId(googleDirectoryId())
                                .setUserId(USER_UUID)
                                .build();
     }
@@ -118,7 +118,7 @@ public class UserTestEnv {
     static Identity githubIdentity() {
         return IdentityVBuilder.newBuilder()
                                .setDisplayName("j.s@github.com")
-                               .setProviderId(githubPoviderId())
+                               .setDirectoryId(githubDirectoryId())
                                .setUserId(USER_UUID)
                                .build();
     }
@@ -127,13 +127,13 @@ public class UserTestEnv {
         return roleId(userOrgEntity(), "editor_role");
     }
 
-    private static DirectoryId googleProviderId() {
+    private static DirectoryId googleDirectoryId() {
         return DirectoryIdVBuilder.newBuilder()
                                          .setValue("gmail.com")
                                          .build();
     }
 
-    private static DirectoryId githubPoviderId() {
+    private static DirectoryId githubDirectoryId() {
         return DirectoryIdVBuilder.newBuilder()
                                          .setValue("github.com")
                                          .build();

--- a/version.gradle
+++ b/version.gradle
@@ -29,7 +29,7 @@
  * already in the root directory.
  */
 
-final def SPINE_VERSION = '1.0.0-pre5'
+final def SPINE_VERSION = '1.0.0-SNAPSHOT'
 
 ext {
     spineBaseVersion = SPINE_VERSION


### PR DESCRIPTION
This PR enables the PMD code analysis for `base` modules.

The one found warning is suppressed.

Also, this PR renames the `IdentityProviderBridge` into `Directory` for the sake of shortness and usage of domain-specific words instead of general-purpose words such as `Provider` and `Bridge`.
