### PR TITLE
Remove public imports

### DIFF
--- a/users/src/main/proto/spine/users/group/events.proto
+++ b/users/src/main/proto/spine/users/group/events.proto
@@ -30,6 +30,7 @@ option java_outer_classname = "EventsProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
+import "spine/core/user_id.proto";
 import "spine/net/email_address.proto";
 import "spine/net/internet_domain.proto";
 import "spine/users/identifiers.proto";

--- a/users/src/main/proto/spine/users/group/group.proto
+++ b/users/src/main/proto/spine/users/group/group.proto
@@ -30,6 +30,7 @@ option java_outer_classname = "GroupProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
+import "spine/core/user_id.proto";
 import "spine/net/internet_domain.proto";
 import "spine/net/email_address.proto";
 import "spine/users/identifiers.proto";

--- a/users/src/main/proto/spine/users/identifiers.proto
+++ b/users/src/main/proto/spine/users/identifiers.proto
@@ -30,7 +30,7 @@ option java_outer_classname = "IdentifiersProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
-import public "spine/core/user_id.proto";
+import "spine/core/user_id.proto";
 
 // A UUID of a user group.
 //

--- a/users/src/main/proto/spine/users/user/commands.proto
+++ b/users/src/main/proto/spine/users/user/commands.proto
@@ -30,6 +30,7 @@ option java_outer_classname = "CommandsProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
+import "spine/core/user_id.proto";
 import "spine/net/internet_domain.proto";
 import "spine/net/email_address.proto";
 import "spine/users/identifiers.proto";

--- a/users/src/main/proto/spine/users/user/events.proto
+++ b/users/src/main/proto/spine/users/user/events.proto
@@ -30,6 +30,7 @@ option java_outer_classname = "EventsProto";
 option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
+import "spine/core/user_id.proto";
 import "spine/net/internet_domain.proto";
 import "spine/net/email_address.proto";
 import "spine/users/identifiers.proto";

--- a/users/src/main/proto/spine/users/user/rejections.proto
+++ b/users/src/main/proto/spine/users/user/rejections.proto
@@ -29,6 +29,7 @@ option java_package = "io.spine.users.user.rejection";
 option java_multiple_files = false;
 option java_generate_equals_and_hash = true;
 
+import "spine/core/user_id.proto";
 import "spine/net/internet_domain.proto";
 import "spine/users/identifiers.proto";
 

--- a/users/src/main/proto/spine/users/user/user.proto
+++ b/users/src/main/proto/spine/users/user/user.proto
@@ -31,6 +31,7 @@ option java_multiple_files = true;
 option java_generate_equals_and_hash = true;
 
 import "google/protobuf/timestamp.proto";
+import "spine/core/user_id.proto";
 import "spine/net/internet_domain.proto";
 import "spine/net/email_address.proto";
 import "spine/users/identifiers.proto";


### PR DESCRIPTION
This PR removes the `import public` construct used in `spine/users/identifiers.proto` as this syntax does not work well with JS generated code.

See [this issue](protocolbuffers/protobuf-javascript#55) for the status of the bug.