### PR TITLE
Update core components

### DIFF
--- a/users/package.json
+++ b/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-users",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "Apache-2.0",
   "description": "Generated Protocol Buffer types for Spine Users library",
   "homepage": "https://spine.io",

--- a/users/package.json
+++ b/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-users",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "description": "Generated Protocol Buffer types for Spine Users library",
   "homepage": "https://spine.io",

--- a/users/src/main/java/io/spine/users/server/group/GroupMembershipPart.java
+++ b/users/src/main/java/io/spine/users/server/group/GroupMembershipPart.java
@@ -83,7 +83,7 @@ public class GroupMembershipPart
 
     @Apply
     void on(JoinedParentGroup event) {
-        getBuilder().addMembership(event.getParentGroupId());
+        builder().addMembership(event.getParentGroupId());
     }
 
     @Apply
@@ -97,7 +97,7 @@ public class GroupMembershipPart
     }
 
     private void removeMembership(GroupId parentGroup) {
-        GroupMembershipVBuilder builder = getBuilder();
+        GroupMembershipVBuilder builder = builder();
         List<GroupId> memberships = builder.getMembership();
         if (memberships.contains(parentGroup)) {
             int index = memberships.indexOf(parentGroup);

--- a/users/src/main/java/io/spine/users/server/group/GroupPart.java
+++ b/users/src/main/java/io/spine/users/server/group/GroupPart.java
@@ -100,18 +100,18 @@ public class GroupPart extends AggregatePart<GroupId, Group, GroupVBuilder, Grou
 
     @Assign
     GroupMoved handle(MoveGroup command) throws CannotMoveExternalGroup {
-        if (getState().getOriginCase() == EXTERNAL_DOMAIN) {
+        if (state().getOriginCase() == EXTERNAL_DOMAIN) {
             throw CannotMoveExternalGroup
                     .newBuilder()
                     .setId(command.getId())
-                    .setExternalDomain(getState().getExternalDomain())
+                    .setExternalDomain(state().getExternalDomain())
                     .build();
         }
         return GroupMovedVBuilder
                 .newBuilder()
                 .setId(command.getId())
                 .setNewOrgEntity(command.getNewOrgEntity())
-                .setOldOrgEntity(getState().getOrgEntity())
+                .setOldOrgEntity(state().getOrgEntity())
                 .build();
     }
 
@@ -135,12 +135,12 @@ public class GroupPart extends AggregatePart<GroupId, Group, GroupVBuilder, Grou
     @Assign
     RoleUnassignedFromGroup handle(UnassignRoleFromGroup command)
             throws RoleIsNotAssignedToGroup {
-        List<RoleId> roles = getState().getRoleList();
+        List<RoleId> roles = state().getRoleList();
         RoleId roleId = command.getRoleId();
         if (!roles.contains(roleId)) {
             throw RoleIsNotAssignedToGroup
                     .newBuilder()
-                    .setId(getId())
+                    .setId(id())
                     .setRoleId(roleId)
                     .build();
         }
@@ -157,7 +157,7 @@ public class GroupPart extends AggregatePart<GroupId, Group, GroupVBuilder, Grou
                 .newBuilder()
                 .setId(command.getId())
                 .setNewName(command.getNewName())
-                .setOldName(getState().getDisplayName())
+                .setOldName(state().getDisplayName())
                 .build();
 
     }
@@ -168,7 +168,7 @@ public class GroupPart extends AggregatePart<GroupId, Group, GroupVBuilder, Grou
                 .newBuilder()
                 .setId(command.getId())
                 .setNewEmail(command.getNewEmail())
-                .setOldEmail(getState().getEmail())
+                .setOldEmail(state().getEmail())
                 .build();
     }
 
@@ -178,13 +178,13 @@ public class GroupPart extends AggregatePart<GroupId, Group, GroupVBuilder, Grou
                 .newBuilder()
                 .setId(command.getId())
                 .setNewDescription(command.getDescription())
-                .setOldDescription(getState().getDescription())
+                .setOldDescription(state().getDescription())
                 .build();
     }
 
     @Apply
     void on(GroupCreated event) {
-        GroupVBuilder builder = getBuilder();
+        GroupVBuilder builder = builder();
         builder.setId(event.getId())
                .setDisplayName(event.getDisplayName())
                .setEmail(event.getEmail())
@@ -205,7 +205,7 @@ public class GroupPart extends AggregatePart<GroupId, Group, GroupVBuilder, Grou
 
     @Apply
     void on(GroupMoved event) {
-        getBuilder().setOrgEntity(event.getNewOrgEntity());
+        builder().setOrgEntity(event.getNewOrgEntity());
     }
 
     @Apply
@@ -215,13 +215,13 @@ public class GroupPart extends AggregatePart<GroupId, Group, GroupVBuilder, Grou
 
     @Apply
     void on(RoleAssignedToGroup event) {
-        getBuilder().addRole(event.getRoleId());
+        builder().addRole(event.getRoleId());
     }
 
     @Apply
     void on(RoleUnassignedFromGroup event) {
         RoleId roleId = event.getRoleId();
-        GroupVBuilder builder = getBuilder();
+        GroupVBuilder builder = builder();
         List<RoleId> roles = builder.getRole();
         if (roles.contains(roleId)) {
             int index = roles.indexOf(roleId);
@@ -231,16 +231,16 @@ public class GroupPart extends AggregatePart<GroupId, Group, GroupVBuilder, Grou
 
     @Apply
     void on(GroupRenamed event) {
-        getBuilder().setDisplayName(event.getNewName());
+        builder().setDisplayName(event.getNewName());
     }
 
     @Apply
     void on(GroupEmailChanged event) {
-        getBuilder().setEmail(event.getNewEmail());
+        builder().setEmail(event.getNewEmail());
     }
 
     @Apply
     void on(GroupDescriptionChanged event) {
-        getBuilder().setDescription(event.getNewDescription());
+        builder().setDescription(event.getNewDescription());
     }
 }

--- a/users/src/main/java/io/spine/users/server/group/GroupRolesPropagationPm.java
+++ b/users/src/main/java/io/spine/users/server/group/GroupRolesPropagationPm.java
@@ -56,7 +56,7 @@ public class GroupRolesPropagationPm
     Collection<RoleInheritedByUser> on(UserJoinedGroup event) {
         UserId newMember = event.getId();
         GroupId groupId = event.getGroupId();
-        getBuilder().setId(groupId)
+        builder().setId(groupId)
                     .addUserMember(newMember);
         List<RoleInheritedByUser> commands = roles()
                 .stream()
@@ -81,7 +81,7 @@ public class GroupRolesPropagationPm
     Collection<RoleInheritedByUser> on(RoleAssignedToGroup event) {
         RoleId assignedRole = event.getRoleId();
         GroupId groupId = event.getId();
-        getBuilder().setId(groupId)
+        builder().setId(groupId)
                     .addRole(assignedRole);
         List<RoleInheritedByUser> commands = members()
                 .stream()
@@ -103,26 +103,26 @@ public class GroupRolesPropagationPm
     }
 
     private void removeMember(UserId member) {
-        List<UserId> members = getBuilder().getUserMember();
+        List<UserId> members = builder().getUserMember();
         int memberIndex = members.indexOf(member);
-        getBuilder().removeUserMember(memberIndex);
+        builder().removeUserMember(memberIndex);
     }
 
     private void removeRole(RoleId role) {
-        List<RoleId> roles = getBuilder().getRole();
+        List<RoleId> roles = builder().getRole();
         int roleIndex = roles.indexOf(role);
-        getBuilder().removeRole(roleIndex);
+        builder().removeRole(roleIndex);
     }
 
     private List<UserId> members() {
-        return getBuilder().getUserMember();
+        return builder().getUserMember();
     }
 
     /**
      * Obtains the roles currently assigned to the group.
      */
     private List<RoleId> roles() {
-        return getBuilder().getRole();
+        return builder().getRole();
     }
 
     private static RoleInheritedByUser roleInherited(GroupId group,

--- a/users/src/main/java/io/spine/users/server/group/GroupRolesPropagationRepository.java
+++ b/users/src/main/java/io/spine/users/server/group/GroupRolesPropagationRepository.java
@@ -35,9 +35,9 @@ public class GroupRolesPropagationRepository
 
     public GroupRolesPropagationRepository() {
         super();
-        getEventRouting().route(UserJoinedGroup.class,
-                                (event, context) -> ImmutableSet.of(event.getGroupId()))
-                         .route(UserLeftGroup.class,
-                                (event, context) -> ImmutableSet.of(event.getGroupId()));
+        eventRouting().route(UserJoinedGroup.class,
+                             (event, context) -> ImmutableSet.of(event.getGroupId()))
+                      .route(UserLeftGroup.class,
+                             (event, context) -> ImmutableSet.of(event.getGroupId()));
     }
 }

--- a/users/src/main/java/io/spine/users/server/group/google/GoogleGroupPart.java
+++ b/users/src/main/java/io/spine/users/server/group/google/GoogleGroupPart.java
@@ -53,14 +53,14 @@ public class GoogleGroupPart
 
     @Apply(allowImport = true)
     void on(GoogleGroupCreated event) {
-        getBuilder().setId(event.getId())
-                    .setGoogleId(event.getGoogleId())
-                    .addAllAlias(event.getAliasList());
+        builder().setId(event.getId())
+                 .setGoogleId(event.getGoogleId())
+                 .addAllAlias(event.getAliasList());
     }
 
     @Apply(allowImport = true)
     void on(GoogleGroupAliasesChanged event) {
-        getBuilder().clearAlias()
-                    .addAllAlias(event.getNewAliasList());
+        builder().clearAlias()
+                 .addAllAlias(event.getNewAliasList());
     }
 }

--- a/users/src/main/java/io/spine/users/server/group/google/GoogleIdMappingProjection.java
+++ b/users/src/main/java/io/spine/users/server/group/google/GoogleIdMappingProjection.java
@@ -51,7 +51,7 @@ public class GoogleIdMappingProjection
     @Subscribe
     public void on(GoogleGroupCreated event) {
         GoogleGroupId googleId = event.getGoogleId();
-        getBuilder().setId(GoogleIdMappingRepository.PROJECTION_ID)
+        builder().setId(GoogleIdMappingRepository.PROJECTION_ID)
                     .putGroups(googleId.getValue(), event.getId());
     }
 }

--- a/users/src/main/java/io/spine/users/server/group/google/GoogleIdMappingRepository.java
+++ b/users/src/main/java/io/spine/users/server/group/google/GoogleIdMappingRepository.java
@@ -52,6 +52,6 @@ public class GoogleIdMappingRepository extends ProjectionRepository<GoogleIdMapp
     @Override
     public void onRegistered() {
         super.onRegistered();
-        getEventRouting().route(GoogleGroupCreated.class, (event, context) -> of(PROJECTION_ID));
+        eventRouting().route(GoogleGroupCreated.class, (event, context) -> of(PROJECTION_ID));
     }
 }

--- a/users/src/main/java/io/spine/users/server/organization/OrganizationAggregate.java
+++ b/users/src/main/java/io/spine/users/server/organization/OrganizationAggregate.java
@@ -92,7 +92,7 @@ public class OrganizationAggregate
                         .newBuilder()
                         .setId(command.getId())
                         .setNewName(command.getNewName())
-                        .setOldName(getState().getDisplayName())
+                        .setOldName(state().getDisplayName())
                         .build();
         return event;
     }
@@ -104,7 +104,7 @@ public class OrganizationAggregate
                         .newBuilder()
                         .setId(command.getId())
                         .setNewDomain(command.getNewDomain())
-                        .setOldDomain(getState().getDomain())
+                        .setOldDomain(state().getDomain())
                         .build();
         return event;
     }
@@ -116,14 +116,14 @@ public class OrganizationAggregate
                         .newBuilder()
                         .setId(command.getId())
                         .setNewTenant(command.getNewTenant())
-                        .setOldTenant(getState().getTenant())
+                        .setOldTenant(state().getTenant())
                         .build();
         return event;
     }
 
     @Apply
     void on(OrganizationCreated event) {
-        getBuilder().setId(event.getId())
+        builder().setId(event.getId())
                     .setDisplayName(event.getDisplayName())
                     .setDomain(event.getDomain())
                     .setTenant(event.getTenant());
@@ -136,16 +136,16 @@ public class OrganizationAggregate
 
     @Apply
     void on(OrganizationRenamed event) {
-        getBuilder().setDisplayName(event.getNewName());
+        builder().setDisplayName(event.getNewName());
     }
 
     @Apply
     void on(OrganizationDomainChanged event) {
-        getBuilder().setDomain(event.getNewDomain());
+        builder().setDomain(event.getNewDomain());
     }
 
     @Apply
     void on(OrganizationTenantChanged event) {
-        getBuilder().setTenant(event.getNewTenant());
+        builder().setTenant(event.getNewTenant());
     }
 }

--- a/users/src/main/java/io/spine/users/server/orgunit/OrgUnitAggregate.java
+++ b/users/src/main/java/io/spine/users/server/orgunit/OrgUnitAggregate.java
@@ -96,7 +96,7 @@ public class OrgUnitAggregate
                         .newBuilder()
                         .setId(command.getId())
                         .setNewParentEntity(command.getNewParentEntity())
-                        .setOldParentEntity(getState().getParentEntity())
+                        .setOldParentEntity(state().getParentEntity())
                         .build();
         return event;
     }
@@ -108,7 +108,7 @@ public class OrgUnitAggregate
                         .newBuilder()
                         .setId(command.getId())
                         .setNewName(command.getNewName())
-                        .setOldName(getState().getDisplayName())
+                        .setOldName(state().getDisplayName())
                         .build();
         return event;
     }
@@ -120,14 +120,14 @@ public class OrgUnitAggregate
                         .newBuilder()
                         .setId(command.getId())
                         .setNewDomain(command.getNewDomain())
-                        .setOldDomain(getState().getDomain())
+                        .setOldDomain(state().getDomain())
                         .build();
         return event;
     }
 
     @Apply
     void on(OrgUnitCreated event) {
-        getBuilder().setId(event.getId())
+        builder().setId(event.getId())
                     .setDisplayName(event.getDisplayName())
                     .setDomain(event.getDomain())
                     .setParentEntity(event.getParentEntity());
@@ -140,16 +140,16 @@ public class OrgUnitAggregate
 
     @Apply
     void on(OrgUnitMoved event) {
-        getBuilder().setParentEntity(event.getNewParentEntity());
+        builder().setParentEntity(event.getNewParentEntity());
     }
 
     @Apply
     void on(OrgUnitRenamed event) {
-        getBuilder().setDisplayName(event.getNewName());
+        builder().setDisplayName(event.getNewName());
     }
 
     @Apply
     void on(OrgUnitDomainChanged event) {
-        getBuilder().setDomain(event.getNewDomain());
+        builder().setDomain(event.getNewDomain());
     }
 }

--- a/users/src/main/java/io/spine/users/server/role/RoleAggregate.java
+++ b/users/src/main/java/io/spine/users/server/role/RoleAggregate.java
@@ -37,9 +37,10 @@ import io.spine.users.role.event.RoleDeletedVBuilder;
  * A role that can be assigned to {@linkplain io.spine.users.server.user.UserPart users} and
  * {@linkplain io.spine.users.server.group.GroupPart groups}, to perform access control.
  *
- * <p>Roles are assigned to {@link io.spine.users.server.user.UserPart users} and {@link io.spine.users.server.group.GroupPart groups} directly
- * and explicitly (please see {@link io.spine.users.user.command.AssignRoleToUser AssignRoleToUser}
- * and {@link io.spine.users.group.command.AssignRoleToGroup AssignRoleToGroup} commands).
+ * <p>Roles are assigned to {@link io.spine.users.server.user.UserPart users} and
+ * {@link io.spine.users.server.group.GroupPart groups} directly and explicitly (please see
+ * {@link io.spine.users.user.command.AssignRoleToUser AssignRoleToUser} and
+ * {@link io.spine.users.group.command.AssignRoleToGroup AssignRoleToGroup} commands).
  *
  * <p>A role exists in the scope of an organization or an orgunit, therefore it can be assigned
  * only to those users and groups that are in the same organization and/or orgunit
@@ -47,13 +48,14 @@ import io.spine.users.role.event.RoleDeletedVBuilder;
  *
  * <h3>Access Control</h3>
  *
- * The roles assigned to a {@linkplain io.spine.users.server.group.GroupPart group} are recursively propagated to all
- * members of the group. This propagation is implicit and is not reflected in aggregate states.
+ * The roles assigned to a {@linkplain io.spine.users.server.group.GroupPart group} are recursively
+ * propagated to all members of the group. This propagation is implicit and is not reflected in
+ * aggregate states.
  *
  * <p>Therefore, when carrying out role-based access control, consider that a
- * {@link io.spine.users.server.user.UserPart User} and {@link io.spine.users.server.group.GroupPart Group}
- * aggregates have not only the roles listed in their aggregate states,
- * but effectively all the roles derived from parent groups.
+ * {@link io.spine.users.server.user.UserPart User} and {@link io.spine.users.server.group.GroupPart
+ * Group} aggregates have not only the roles listed in their aggregate states, but effectively all
+ * the roles derived from parent groups.
  */
 public class RoleAggregate extends Aggregate<RoleId, Role, RoleVBuilder> {
 
@@ -87,7 +89,7 @@ public class RoleAggregate extends Aggregate<RoleId, Role, RoleVBuilder> {
     @Apply
     void on(RoleCreated event) {
         RoleId id = event.getId();
-        getBuilder().setId(id)
+        builder().setId(id)
                     .setDisplayName(id.getName())
                     .setOrgEntity(id.getOrgEntity())
                     .build();

--- a/users/src/main/java/io/spine/users/server/signin/SignInPm.java
+++ b/users/src/main/java/io/spine/users/server/signin/SignInPm.java
@@ -122,7 +122,7 @@ public class SignInPm extends ProcessManager<UserId, SignIn, SignInVBuilder> {
             return withA(finishWithError(UNSUPPORTED_IDENTITY));
         }
 
-        SignInVBuilder builder = getBuilder().setId(id)
+        SignInVBuilder builder = builder().setId(id)
                                              .setIdentity(identity);
         Directory directory = directoryOptional.get();
         if (!directory.hasIdentity(identity)) {
@@ -148,7 +148,7 @@ public class SignInPm extends ProcessManager<UserId, SignIn, SignInVBuilder> {
     @Command
     Optional<SignUserIn> on(UserCreated event) {
         if (awaitsUserCreation()) {
-            return of(signIn(getBuilder().getIdentity()));
+            return of(signIn(builder().getIdentity()));
         }
         return empty();
     }
@@ -156,7 +156,7 @@ public class SignInPm extends ProcessManager<UserId, SignIn, SignInVBuilder> {
     @Assign
     EitherOf2<SignInSuccessful, SignInFailed> handle(FinishSignIn command) {
         UserId id = command.getId();
-        Identity identity = getBuilder().getIdentity();
+        Identity identity = builder().getIdentity();
         if (command.getSuccessful()) {
             return withA(signInSuccessful(id, identity));
         } else {
@@ -171,16 +171,16 @@ public class SignInPm extends ProcessManager<UserId, SignIn, SignInVBuilder> {
     }
 
     private CreateUser createUser(Directory directory) {
-        PersonProfile profile = directory.fetchProfile(getBuilder().getIdentity());
-        return createUser(getBuilder().getIdentity(), profile);
+        PersonProfile profile = directory.fetchProfile(builder().getIdentity());
+        return createUser(builder().getIdentity(), profile);
     }
 
     private boolean awaitsUserCreation() {
-        return getBuilder().getStatus() == AWAITING_USER_AGGREGATE_CREATION;
+        return builder().getStatus() == AWAITING_USER_AGGREGATE_CREATION;
     }
 
     private static boolean identityBelongsToUser(UserPart user, Identity identity) {
-        User userState = user.getState();
+        User userState = user.state();
         if (userState.getPrimaryIdentity()
                      .equals(identity)) {
             return true;
@@ -192,7 +192,7 @@ public class SignInPm extends ProcessManager<UserId, SignIn, SignInVBuilder> {
     FinishSignIn finishWithError(SignInFailureReason failureReason) {
         return FinishSignInVBuilder
                 .newBuilder()
-                .setId(getId())
+                .setId(id())
                 .setSuccessful(false)
                 .setFailureReason(failureReason)
                 .build();
@@ -201,7 +201,7 @@ public class SignInPm extends ProcessManager<UserId, SignIn, SignInVBuilder> {
     FinishSignIn finishSuccessfully() {
         return FinishSignInVBuilder
                 .newBuilder()
-                .setId(getId())
+                .setId(id())
                 .setSuccessful(true)
                 .build();
     }
@@ -209,7 +209,7 @@ public class SignInPm extends ProcessManager<UserId, SignIn, SignInVBuilder> {
     SignUserIn signIn(Identity identity) {
         return SignUserInVBuilder
                 .newBuilder()
-                .setId(getId())
+                .setId(id())
                 .setIdentity(identity)
                 .build();
     }
@@ -219,7 +219,7 @@ public class SignInPm extends ProcessManager<UserId, SignIn, SignInVBuilder> {
                                     .getValue();
         return CreateUserVBuilder
                 .newBuilder()
-                .setId(getId())
+                .setId(id())
                 .setDisplayName(displayName)
                 .setPrimaryIdentity(identity)
                 .setProfile(profile)

--- a/users/src/main/java/io/spine/users/server/user/UserMembershipPart.java
+++ b/users/src/main/java/io/spine/users/server/user/UserMembershipPart.java
@@ -84,8 +84,8 @@ public class UserMembershipPart
                         .setGroupId(event.getGroupId())
                         .setRole(event.getRole())
                         .build();
-        getBuilder()
-                .setId(getId())
+        builder()
+                .setId(id())
                 .addMembership(membershipRecord);
     }
 
@@ -96,14 +96,14 @@ public class UserMembershipPart
     }
 
     private void removeMembership(UserMembershipRecord record) {
-        int index = getBuilder().getMembership()
+        int index = builder().getMembership()
                                 .indexOf(record);
-        getBuilder().removeMembership(index);
+        builder().removeMembership(index);
     }
 
     private Optional<UserMembershipRecord> findMembership(GroupId groupId) {
         Optional<UserMembershipRecord> record =
-                getBuilder().getMembership()
+                builder().getMembership()
                             .stream()
                             .filter(membership -> membership.getGroupId()
                                                             .equals(groupId))

--- a/users/src/main/java/io/spine/users/server/user/UserPart.java
+++ b/users/src/main/java/io/spine/users/server/user/UserPart.java
@@ -138,11 +138,11 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
 
     @Assign
     UserMoved handle(MoveUser command, CommandContext context) throws CannotMoveExternalUser {
-        if (getState().getOriginCase() == EXTERNAL_DOMAIN) {
+        if (state().getOriginCase() == EXTERNAL_DOMAIN) {
             throw CannotMoveExternalUser
                     .newBuilder()
                     .setId(command.getId())
-                    .setExternalDomain(getState().getExternalDomain())
+                    .setExternalDomain(state().getExternalDomain())
                     .build();
         }
         UserMoved event =
@@ -150,7 +150,7 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
                         .newBuilder()
                         .setId(command.getId())
                         .setNewOrgEntity(command.getNewOrgEntity())
-                        .setOldOrgEntity(getState().getOrgEntity())
+                        .setOldOrgEntity(state().getOrgEntity())
                         .build();
         return event;
     }
@@ -179,12 +179,12 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
     @Assign
     RoleUnassignedFromUser handle(UnassignRoleFromUser command, CommandContext context)
             throws RoleIsNotAssignedToUser {
-        List<RoleId> roles = getState().getRoleList();
+        List<RoleId> roles = state().getRoleList();
         RoleId roleId = command.getRoleId();
         if (!roles.contains(roleId)) {
             throw RoleIsNotAssignedToUser
                     .newBuilder()
-                    .setId(getId())
+                    .setId(id())
                     .setRoleId(roleId)
                     .build();
         }
@@ -204,7 +204,7 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
                         .newBuilder()
                         .setId(command.getId())
                         .setNewStatus(command.getStatus())
-                        .setOldStatus(getState().getStatus())
+                        .setOldStatus(state().getStatus())
                         .build();
         return event;
     }
@@ -255,7 +255,7 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
                         .newBuilder()
                         .setId(command.getId())
                         .setNewName(command.getNewName())
-                        .setOldName(getState().getDisplayName())
+                        .setOldName(state().getDisplayName())
                         .build();
         return event;
     }
@@ -273,7 +273,7 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
 
     @Apply
     void on(UserCreated event) {
-        UserVBuilder builder = getBuilder();
+        UserVBuilder builder = builder();
         builder.setId(event.getId())
                     .setDisplayName(event.getDisplayName())
                     .setPrimaryIdentity(event.getPrimaryIdentity())
@@ -297,7 +297,7 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
 
     @Apply
     void on(UserMoved event) {
-        getBuilder().setOrgEntity(event.getNewOrgEntity());
+        builder().setOrgEntity(event.getNewOrgEntity());
     }
 
     @Apply
@@ -307,7 +307,7 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
 
     @Apply
     void on(RoleAssignedToUser event) {
-        getBuilder().addRole(event.getRoleId());
+        builder().addRole(event.getRoleId());
     }
 
     @Apply
@@ -317,12 +317,12 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
 
     @Apply
     void on(UserStatusChanged event) {
-        getBuilder().setStatus(event.getNewStatus());
+        builder().setStatus(event.getNewStatus());
     }
 
     @Apply
     void on(SecondaryIdentityAdded event) {
-        getBuilder().addSecondaryIdentity(event.getIdentity());
+        builder().addSecondaryIdentity(event.getIdentity());
     }
 
     @Apply
@@ -332,39 +332,39 @@ public class UserPart extends AggregatePart<UserId, User, UserVBuilder, UserRoot
 
     @Apply
     void on(PrimaryIdentityChanged event) {
-        getBuilder().setPrimaryIdentity(event.getIdentity());
+        builder().setPrimaryIdentity(event.getIdentity());
     }
 
     @Apply
     void on(UserRenamed event) {
-        getBuilder().setDisplayName(event.getNewName());
+        builder().setDisplayName(event.getNewName());
     }
 
     @Apply
     void on(PersonProfileUpdated event) {
-        getBuilder().setProfile(event.getUpdatedProfile());
+        builder().setProfile(event.getUpdatedProfile());
     }
 
     private Optional<Identity> findAuthIdentity(RemoveSecondaryIdentity command) {
-        return getState().getSecondaryIdentityList()
-                         .stream()
-                         .filter(identityMatcher(command))
-                         .findFirst();
+        return state().getSecondaryIdentityList()
+                      .stream()
+                      .filter(identityMatcher(command))
+                      .findFirst();
     }
 
     private void removeRole(RoleId roleId) {
-        List<RoleId> roles = getBuilder().getRole();
+        List<RoleId> roles = builder().getRole();
         if (roles.contains(roleId)) {
             int index = roles.indexOf(roleId);
-            getBuilder().removeRole(index);
+            builder().removeRole(index);
         }
     }
 
     private void removeIdentity(Identity identity) {
-        List<Identity> identities = getBuilder().getSecondaryIdentity();
+        List<Identity> identities = builder().getSecondaryIdentity();
         if (identities.contains(identity)) {
             int index = identities.indexOf(identity);
-            getBuilder().removeSecondaryIdentity(index);
+            builder().removeSecondaryIdentity(index);
         }
     }
 

--- a/users/src/main/java/io/spine/users/server/user/UserRolesProjection.java
+++ b/users/src/main/java/io/spine/users/server/user/UserRolesProjection.java
@@ -44,13 +44,13 @@ public class UserRolesProjection extends Projection<UserId, UserRoles, UserRoles
     @Subscribe
     public void on(UserCreated event) {
         UserId userId = event.getId();
-        getBuilder().setId(userId);
+        builder().setId(userId);
     }
 
     @Subscribe
     public void on(RoleInheritedByUser event) {
         RoleId inheritedRole = event.getRoleId();
-        getBuilder().addRole(inheritedRole);
+        builder().addRole(inheritedRole);
     }
 
     @Subscribe
@@ -61,7 +61,7 @@ public class UserRolesProjection extends Projection<UserId, UserRoles, UserRoles
     @Subscribe
     public void on(RoleAssignedToUser event) {
         RoleId assignedRole = event.getRoleId();
-        getBuilder().addRole(assignedRole);
+        builder().addRole(assignedRole);
     }
 
     @Subscribe
@@ -70,8 +70,8 @@ public class UserRolesProjection extends Projection<UserId, UserRoles, UserRoles
     }
 
     private void removeRole(RoleId roleId) {
-        int roleIndex = getBuilder().getRole()
-                                    .indexOf(roleId);
-        getBuilder().removeRole(roleIndex);
+        int roleIndex = builder().getRole()
+                                 .indexOf(roleId);
+        builder().removeRole(roleIndex);
     }
 }

--- a/users/src/main/java/io/spine/users/server/user/UserRolesRepository.java
+++ b/users/src/main/java/io/spine/users/server/user/UserRolesRepository.java
@@ -35,9 +35,9 @@ public class UserRolesRepository
 
     public UserRolesRepository() {
         super();
-        getEventRouting().route(RoleInheritedByUser.class,
-                                (event, context) -> ImmutableSet.of(event.getUserId()))
-                         .route(RoleDisinheritedByUser.class,
-                                (event, context) -> ImmutableSet.of(event.getUserId()));
+        eventRouting().route(RoleInheritedByUser.class,
+                             (event, context) -> ImmutableSet.of(event.getUserId()))
+                      .route(RoleDisinheritedByUser.class,
+                             (event, context) -> ImmutableSet.of(event.getUserId()));
     }
 }

--- a/users/src/main/java/io/spine/users/server/user/UserRoot.java
+++ b/users/src/main/java/io/spine/users/server/user/UserRoot.java
@@ -26,7 +26,7 @@ import io.spine.server.BoundedContext;
 import io.spine.server.aggregate.AggregateRoot;
 
 /**
- * The {@link User} aggregate root.
+ * The {@link io.spine.users.user.User} aggregate root.
  *
  * @author Vladyslav Lubenskyi
  */
@@ -40,7 +40,7 @@ public class UserRoot extends AggregateRoot<UserId> {
     }
 
     /**
-     * A test method to obtain obtains a new {@link UserRoot}.
+     * A test method to obtain obtains a new {@code UserRoot}.
      */
     @VisibleForTesting
     public static UserRoot getForTest(BoundedContext boundedContext, UserId id) {

--- a/users/src/main/proto/spine/users/group/commands.proto
+++ b/users/src/main/proto/spine/users/group/commands.proto
@@ -1,4 +1,3 @@
-//
 // Copyright 2019, TeamDev. All rights reserved.
 //
 // Redistribution and use in source and/or binary forms, with or without
@@ -37,7 +36,6 @@ import "spine/users/identifiers.proto";
 // Creates a group.
 //
 message CreateGroup {
-    option (events) = "GroupCreated";
 
     GroupId id = 1;
 
@@ -64,8 +62,6 @@ message CreateGroup {
 // Moves a group from one organization or orgunit to another.
 //
 message MoveGroup {
-    option (events) = "GroupMoved";
-    option (rejections) = "CannotMoveExternalGroup";
 
     GroupId id = 1;
 
@@ -76,7 +72,6 @@ message MoveGroup {
 // Deletes a group.
 //
 message DeleteGroup {
-    option (events) = "GroupDeleted";
 
     GroupId id = 1;
 }
@@ -84,8 +79,6 @@ message DeleteGroup {
 // Joins a parent group.
 //
 message JoinParentGroup {
-    option (events) = "JoinedParentGroup";
-    option (rejections) = "GroupsCannotFormCycles";
 
     GroupId id = 1;
 
@@ -96,7 +89,6 @@ message JoinParentGroup {
 // Leaves a parent group.
 //
 message LeaveParentGroup {
-    option (events) = "LeftParentGroup";
 
     GroupId id = 1;
 
@@ -107,7 +99,6 @@ message LeaveParentGroup {
 // Assigns a role to the group.
 //
 message AssignRoleToGroup {
-    option (events) = "RoleAssignedToGroup";
 
     GroupId id = 1;
 
@@ -118,8 +109,6 @@ message AssignRoleToGroup {
 // Removes a role assignment from the group.
 //
 message UnassignRoleFromGroup {
-    option (events) = "RoleUnassignedFromGroup";
-    option (rejections) = "RoleIsNotAssignedToGroup";
 
     GroupId id = 1;
 
@@ -130,7 +119,6 @@ message UnassignRoleFromGroup {
 // Renames a group.
 //
 message RenameGroup {
-    option (events) = "GroupRenamed";
 
     GroupId id = 1;
 
@@ -141,7 +129,6 @@ message RenameGroup {
 // Changes a group email address.
 //
 message ChangeGroupEmail {
-    option (events) = "GroupEmailChanged";
 
     GroupId id = 1;
 
@@ -152,7 +139,6 @@ message ChangeGroupEmail {
 // Changes a description of a group.
 //
 message ChangeGroupDescription {
-    option (events) = "GroupDescriptionChanged";
 
     GroupId id = 1;
 

--- a/users/src/main/proto/spine/users/organization/commands.proto
+++ b/users/src/main/proto/spine/users/organization/commands.proto
@@ -37,7 +37,6 @@ import "spine/users/identifiers.proto";
 // Creates an organization.
 //
 message CreateOrganization {
-    option (events) = "OrganizationCreated";
 
     OrganizationId id = 1;
 
@@ -54,7 +53,6 @@ message CreateOrganization {
 // Deletes an organization.
 //
 message DeleteOrganization {
-    option (events) = "OrganizationDeleted";
 
     OrganizationId id = 1;
 }
@@ -62,7 +60,6 @@ message DeleteOrganization {
 // Renames an organization.
 //
 message RenameOrganization {
-    option (events) = "OrganizationRenamed";
 
     OrganizationId id = 1;
 
@@ -73,7 +70,6 @@ message RenameOrganization {
 // Changes an organization domain.
 //
 message ChangeOrganizationDomain {
-    option (events) = "OrganizationDomainChanged";
 
     OrganizationId id = 1;
 
@@ -84,7 +80,6 @@ message ChangeOrganizationDomain {
 // Changes an organization tenant.
 //
 message ChangeOrganizationTenant {
-    option (events) = "OrganizationTenantChanged";
 
     OrganizationId id = 1;
 

--- a/users/src/main/proto/spine/users/orgunit/commands.proto
+++ b/users/src/main/proto/spine/users/orgunit/commands.proto
@@ -36,8 +36,6 @@ import "spine/users/identifiers.proto";
 // Creates an organizational unit.
 //
 message CreateOrgUnit {
-    option (events) = "OrgUnitCreated";
-    option (rejections) = "OrgUnitsCannotFormCycles";
 
     OrgUnitId id = 1;
 
@@ -54,8 +52,6 @@ message CreateOrgUnit {
 // Moves an orgunit from one organization or orgunit to another.
 //
 message MoveOrgUnit {
-    option (events) = "OrgUnitMoved";
-    option (rejections) = "OrgUnitsCannotFormCycles";
 
     OrgUnitId id = 1;
 
@@ -66,7 +62,6 @@ message MoveOrgUnit {
 // Deletes an orgunit.
 //
 message DeleteOrgUnit {
-    option (events) = "OrgUnitDeleted";
 
     OrgUnitId id = 1;
 }
@@ -74,7 +69,6 @@ message DeleteOrgUnit {
 // Renames an orgunit.
 //
 message RenameOrgUnit {
-    option (events) = "OrgUnitRenamed";
 
     OrgUnitId id = 1;
 
@@ -85,7 +79,6 @@ message RenameOrgUnit {
 // Changes an orgunit domain.
 //
 message ChangeOrgUnitDomain {
-    option (events) = "OrgUnitDomainChanged";
 
     OrgUnitId id = 1;
 

--- a/users/src/main/proto/spine/users/role/commands.proto
+++ b/users/src/main/proto/spine/users/role/commands.proto
@@ -35,7 +35,6 @@ import "spine/users/identifiers.proto";
 // Creates a role.
 //
 message CreateRole {
-    option (events) = "RoleCreated";
 
     RoleId id = 1;
 }
@@ -43,7 +42,6 @@ message CreateRole {
 // Deletes a role.
 //
 message DeleteRole {
-    option (events) = "RoleDeleted";
 
     RoleId id = 1;
 }

--- a/users/src/main/proto/spine/users/signin/commands.proto
+++ b/users/src/main/proto/spine/users/signin/commands.proto
@@ -47,7 +47,6 @@ message SignUserIn {
 // Signs a user out.
 //
 message SignUserOut {
-    option (events) = "SignOutCompleted";
 
     core.UserId id = 1;
 }
@@ -58,7 +57,6 @@ message SignUserOut {
 //
 message FinishSignIn {
     option (internal_type) = true;
-    option (events) = "SignInSuccessful, SignInFailed";
 
     core.UserId id = 1;
 

--- a/users/src/main/proto/spine/users/user/commands.proto
+++ b/users/src/main/proto/spine/users/user/commands.proto
@@ -41,7 +41,6 @@ import "spine/users/user/identity.proto";
 // Creates a new user.
 //
 message CreateUser {
-    option (events) = "UserCreated";
 
     core.UserId id = 1;
 
@@ -77,8 +76,6 @@ message CreateUser {
 // Moves a user from one organization or organizational unit to another.
 //
 message MoveUser {
-    option (events) = "UserMoved";
-    option (rejections) = "CannotMoveExternalUser";
 
     core.UserId id = 1;
 
@@ -89,7 +86,6 @@ message MoveUser {
 // Joins a group.
 //
 message JoinGroup {
-    option (events) = "UserJoinedGroup";
 
     core.UserId id = 1;
 
@@ -103,7 +99,6 @@ message JoinGroup {
 // Leaves a group.
 //
 message LeaveGroup {
-    option (events) = "UserLeftGroup";
 
     core.UserId id = 1;
 
@@ -114,7 +109,6 @@ message LeaveGroup {
 // Deletes a user.
 //
 message DeleteUser {
-    option (events) = "UserDeleted";
 
     core.UserId id = 1;
 }
@@ -122,7 +116,6 @@ message DeleteUser {
 // Assigns a role to a user.
 //
 message AssignRoleToUser {
-    option (events) = "RoleAssignedToUser";
 
     core.UserId id = 1;
 
@@ -133,8 +126,6 @@ message AssignRoleToUser {
 // Removes a role assignment from a user.
 //
 message UnassignRoleFromUser {
-    option (events) = "RoleUnassignedFromUser";
-    option (rejections) = "RoleIsNotAssignedToUser";
 
     core.UserId id = 1;
 
@@ -145,7 +136,6 @@ message UnassignRoleFromUser {
 // Changes the user status.
 //
 message ChangeUserStatus {
-    option (events) = "UserStatusChanged";
 
     core.UserId id = 1;
 
@@ -156,7 +146,6 @@ message ChangeUserStatus {
 // Adds a new secondary identity to the user.
 //
 message AddSecondaryIdentity {
-    option (events) = "SecondaryIdentityAdded";
 
     core.UserId id = 1;
 
@@ -167,8 +156,6 @@ message AddSecondaryIdentity {
 // Removes a secondary identity of the user.
 //
 message RemoveSecondaryIdentity {
-    option (events) = "SecondaryIdentityRemoved";
-    option (rejections) = "IdentityDoesNotExist";
 
     core.UserId id = 1;
 
@@ -182,7 +169,6 @@ message RemoveSecondaryIdentity {
 // Changes the primary identity.
 //
 message ChangePrimaryIdentity {
-    option (events) = "PrimaryIdentityChanged";
 
     core.UserId id = 1;
 
@@ -193,7 +179,6 @@ message ChangePrimaryIdentity {
 // Renames a user.
 //
 message RenameUser {
-    option (events) = "UserRenamed";
 
     core.UserId id = 1;
 
@@ -204,7 +189,6 @@ message RenameUser {
 // Updates a user profile.
 //
 message UpdatePersonProfile {
-    option (events) = "PersonProfileUpdated";
 
     core.UserId id = 1;
 

--- a/users/src/test/java/io/spine/users/server/group/ChangeGroupDescriptionTest.java
+++ b/users/src/test/java/io/spine/users/server/group/ChangeGroupDescriptionTest.java
@@ -42,7 +42,7 @@ class ChangeGroupDescriptionTest extends GroupCommandTest<ChangeGroupDescription
     @DisplayName("produce GroupDescriptionChanged event")
     void produceEvent() {
         GroupPart aggregate = createPartWithState();
-        String oldDescription = aggregate.getState()
+        String oldDescription = aggregate.state()
                                          .getDescription();
         expectThat(aggregate).producesEvent(GroupDescriptionChanged.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/group/ChangeGroupEmailTest.java
+++ b/users/src/test/java/io/spine/users/server/group/ChangeGroupEmailTest.java
@@ -43,7 +43,7 @@ class ChangeGroupEmailTest extends GroupCommandTest<ChangeGroupEmail> {
     @DisplayName("produce GroupEmailChanged event")
     void produceEvent() {
         GroupPart aggregate = createPartWithState();
-        EmailAddress oldEmail = aggregate.getState()
+        EmailAddress oldEmail = aggregate.state()
                                          .getEmail();
         expectThat(aggregate).producesEvent(GroupEmailChanged.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/group/MoveGroupTest.java
+++ b/users/src/test/java/io/spine/users/server/group/MoveGroupTest.java
@@ -46,7 +46,7 @@ class MoveGroupTest extends GroupCommandTest<MoveGroup> {
     @DisplayName("produce GroupMoved event")
     void produceEvent() {
         GroupPart aggregate = createPartWithState();
-        OrganizationOrUnit oldParent = aggregate.getState()
+        OrganizationOrUnit oldParent = aggregate.state()
                                                 .getOrgEntity();
         expectThat(aggregate).producesEvent(GroupMoved.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/group/RenameGroupTest.java
+++ b/users/src/test/java/io/spine/users/server/group/RenameGroupTest.java
@@ -42,7 +42,7 @@ class RenameGroupTest extends GroupCommandTest<RenameGroup> {
     @DisplayName("produce GroupRenamed event")
     void produceEvent() {
         GroupPart aggregate = createPartWithState();
-        String oldName = aggregate.getState()
+        String oldName = aggregate.state()
                                   .getDisplayName();
         expectThat(aggregate).producesEvent(GroupRenamed.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/organization/ChangeOrganizationDomainTest.java
+++ b/users/src/test/java/io/spine/users/server/organization/ChangeOrganizationDomainTest.java
@@ -43,7 +43,7 @@ class ChangeOrganizationDomainTest extends OrgCommandTest<ChangeOrganizationDoma
     @DisplayName("produce OrganizationDomainChanged event")
     void produceEvent() {
         OrganizationAggregate aggregate = TestOrganizationFactory.createAggregate(ORG_ID);
-        InternetDomain oldDomain = aggregate.getState()
+        InternetDomain oldDomain = aggregate.state()
                                             .getDomain();
         expectThat(aggregate).producesEvent(OrganizationDomainChanged.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/organization/ChangeOrganizationTenantTest.java
+++ b/users/src/test/java/io/spine/users/server/organization/ChangeOrganizationTenantTest.java
@@ -43,7 +43,7 @@ class ChangeOrganizationTenantTest extends OrgCommandTest<ChangeOrganizationTena
     @DisplayName("produce OrganizationTenantChanged event")
     void produceEvent() {
         OrganizationAggregate aggregate = TestOrganizationFactory.createAggregate(ORG_ID);
-        TenantId oldTenant = aggregate.getState()
+        TenantId oldTenant = aggregate.state()
                                       .getTenant();
         expectThat(aggregate).producesEvent(OrganizationTenantChanged.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/organization/RenameOrganizationTest.java
+++ b/users/src/test/java/io/spine/users/server/organization/RenameOrganizationTest.java
@@ -42,7 +42,7 @@ class RenameOrganizationTest extends OrgCommandTest<RenameOrganization> {
     @DisplayName("produce OrganizationRenamed event")
     void produceEvent() {
         OrganizationAggregate aggregate = TestOrganizationFactory.createAggregate(ORG_ID);
-        String oldName = aggregate.getState()
+        String oldName = aggregate.state()
                                   .getDisplayName();
         expectThat(aggregate).producesEvent(OrganizationRenamed.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/orgunit/ChangeOrgUnitDomainTest.java
+++ b/users/src/test/java/io/spine/users/server/orgunit/ChangeOrgUnitDomainTest.java
@@ -44,7 +44,7 @@ class ChangeOrgUnitDomainTest extends OrgUnitCommandTest<ChangeOrgUnitDomain> {
     @DisplayName("produce OrgUnitDomainChanged event")
     void produceEvent() {
         OrgUnitAggregate aggregate = createAggregate(ORG_UNIT_ID);
-        InternetDomain oldDomain = aggregate.getState()
+        InternetDomain oldDomain = aggregate.state()
                                             .getDomain();
         expectThat(aggregate).producesEvent(OrgUnitDomainChanged.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/orgunit/MoveOrgUnitTest.java
+++ b/users/src/test/java/io/spine/users/server/orgunit/MoveOrgUnitTest.java
@@ -43,7 +43,7 @@ class MoveOrgUnitTest extends OrgUnitCommandTest<MoveOrgUnit> {
     @DisplayName("produce OrgUnitMoved event")
     void produceEvent() {
         OrgUnitAggregate aggregate = TestOrgUnitFactory.createAggregate(ORG_UNIT_ID);
-        OrganizationOrUnit oldParent = aggregate.getState()
+        OrganizationOrUnit oldParent = aggregate.state()
                                                   .getParentEntity();
         expectThat(aggregate).producesEvent(OrgUnitMoved.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/orgunit/RenameOrgUnitTest.java
+++ b/users/src/test/java/io/spine/users/server/orgunit/RenameOrgUnitTest.java
@@ -42,7 +42,7 @@ class RenameOrgUnitTest extends OrgUnitCommandTest<RenameOrgUnit> {
     @DisplayName("produce OrgUnitRenamed event")
     void produceEvent() {
         OrgUnitAggregate aggregate = TestOrgUnitFactory.createAggregate(ORG_UNIT_ID);
-        String oldName = aggregate.getState()
+        String oldName = aggregate.state()
                                   .getDisplayName();
         expectThat(aggregate).producesEvent(OrgUnitRenamed.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/signin/FinishSignInTest.java
+++ b/users/src/test/java/io/spine/users/server/signin/FinishSignInTest.java
@@ -41,8 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 
 @DisplayName("SignInPm should")
-@SuppressWarnings("InnerClassMayBeStatic")
-        // JUnit doesn't support static classes.
+@SuppressWarnings("InnerClassMayBeStatic") // JUnit doesn't support static classes.
 class FinishSignInTest {
 
     @Nested
@@ -58,7 +57,7 @@ class FinishSignInTest {
         void generatesEvent() {
             SignInPm procMan = nonEmptyProcMan(COMPLETED);
             expectThat(procMan).producesEvent(SignInSuccessful.class, event -> {
-                SignIn state = procMan.getState();
+                SignIn state = procMan.state();
                 assertEquals(state.getId(), event.getId());
                 assertEquals(state.getIdentity(), event.getIdentity());
             });
@@ -78,7 +77,7 @@ class FinishSignInTest {
         void generatesEvent() {
             SignInPm procMan = nonEmptyProcMan(COMPLETED);
             expectThat(procMan).producesEvent(SignInFailed.class, event -> {
-                SignIn state = procMan.getState();
+                SignIn state = procMan.state();
                 assertEquals(state.getId(), event.getId());
                 assertEquals(state.getIdentity(), event.getIdentity());
                 assertEquals(failureReason(), event.getFailureReason());

--- a/users/src/test/java/io/spine/users/server/signin/UserCreatedEventTest.java
+++ b/users/src/test/java/io/spine/users/server/signin/UserCreatedEventTest.java
@@ -53,7 +53,7 @@ public class UserCreatedEventTest
         SignInPm emptyProcMan = nonEmptyProcMan(AWAITING_USER_AGGREGATE_CREATION);
         expectThat(emptyProcMan).producesCommand(SignUserIn.class, command -> {
             assertEquals(message().getId(), command.getId());
-            assertEquals(emptyProcMan.getState()
+            assertEquals(emptyProcMan.state()
                                      .getIdentity(), command.getIdentity());
         });
     }

--- a/users/src/test/java/io/spine/users/server/user/MoveUserTest.java
+++ b/users/src/test/java/io/spine/users/server/user/MoveUserTest.java
@@ -43,7 +43,7 @@ class MoveUserTest extends UserPartCommandTest<MoveUser> {
     @DisplayName("generate UserMoved event")
     void generateEvent() {
         UserPart aggregate = createPartWithState();
-        OrganizationOrUnit oldParent = aggregate.getState()
+        OrganizationOrUnit oldParent = aggregate.state()
                                                   .getOrgEntity();
         expectThat(aggregate).producesEvent(UserMoved.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/users/src/test/java/io/spine/users/server/user/RenameUserTest.java
+++ b/users/src/test/java/io/spine/users/server/user/RenameUserTest.java
@@ -42,7 +42,7 @@ class RenameUserTest extends UserPartCommandTest<RenameUser> {
     @DisplayName("generate UserRenamed event")
     void generateEvent() {
         UserPart aggregate = createPartWithState();
-        String oldName = aggregate.getState()
+        String oldName = aggregate.state()
                                   .getDisplayName();
         expectThat(aggregate).producesEvent(UserRenamed.class, event -> {
             assertEquals(message().getId(), event.getId());

--- a/version.gradle
+++ b/version.gradle
@@ -29,12 +29,12 @@
  * already in the root directory.
  */
 
-final def SPINE_VERSION = '1.0.0-SNAPSHOT'
+final def SPINE_VERSION = '1.0.0-pre6'
 
 ext {
     spineBaseVersion = SPINE_VERSION
     spineVersion = SPINE_VERSION
     versionToPublish = SPINE_VERSION
     // Have a different version for JS since NPM doesn't allow to publish the same version twice.
-    versionToPublishJs = '0.14.0'
+    versionToPublishJs = '0.14.1'
 }

--- a/version.gradle
+++ b/version.gradle
@@ -36,5 +36,5 @@ ext {
     spineVersion = SPINE_VERSION
     versionToPublish = SPINE_VERSION
     // Have a different version for JS since NPM doesn't allow to publish the same version twice.
-    versionToPublishJs = '0.14.1'
+    versionToPublishJs = '0.15.0'
 }


### PR DESCRIPTION
In this PR we update `base` and `core-java` dependencies. The new version is `1.0.0-pre6`.

Changes:
 - getter style (from `getSomething()` to `something()`);
 - removed deleted options `(events)` and `(rejections)`;
 - fixed some Javadoc warnings.