### PR TITLE
Update to the latest versions of `core`, `base` and third-party dependencies

### DIFF
--- a/users/package-lock.json
+++ b/users/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-users",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/users/package.json
+++ b/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spine-users",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "license": "Apache-2.0",
   "description": "Generated Protocol Buffer types for Spine Users library",
   "homepage": "https://spine.io",

--- a/version.gradle
+++ b/version.gradle
@@ -36,5 +36,5 @@ ext {
     spineVersion = SPINE_VERSION
     versionToPublish = SPINE_VERSION
     // Have a different version for JS since NPM doesn't allow to publish the same version twice.
-    versionToPublishJs = '0.15.0'
+    versionToPublishJs = '0.15.1'
 }


### PR DESCRIPTION
Also, the JS library version was set to `0.15.1`.